### PR TITLE
Make ambiguous and hidden characters easier to identify in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+  "editor.unicodeHighlight.ambiguousCharacters": true,
+  "editor.unicodeHighlight.invisibleCharacters": true,
   "typescript.preferences.importModuleSpecifier": "project-relative",
   "typescript.preferences.importModuleSpecifierEnding": "js",
   "typescript.preferences.preferTypeOnlyAutoImports": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+## 1.0.4
+
+- Make ambiguous and hidden characters easier to identify in VSCode by enabling the following settings:
+  - `editor.unicodeHighlight.ambiguousCharacters`
+  - `editor.unicodeHighlight.invisibleCharacters`
+
 ## 1.0.3
 
-- `getElapsedTimeFormatted()` now uses `ms` units by default
+- `getElapsedTimeFormatted()` now uses `ms` units by default to match Bun's output
 - Update dependency versions to latest
 
 ## 1.0.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in [`package.json`](/package.json) following [Semantic Versioning](http://semver.org/)

**Changes Included**

- Version bump to `1.0.4`
- Make ambiguous and hidden characters easier to identify in VSCode by enabling the following settings:
  - `editor.unicodeHighlight.ambiguousCharacters`
  - `editor.unicodeHighlight.invisibleCharacters`

> [!NOTE]
> Learned from [this Bun PR](https://github.com/oven-sh/bun/pull/9066) about the same topic