### PR TITLE
Add HTTPS serving with optional custom hostname support to the dev server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.1.0
+
+- Added additional functionality to `utils/networkUtils.mts` -> `startDevelopmentServer()`
+  - HTTPS serving with optional custom hostname support
+  - Using any option that `Bun.serve()` accepts via an override parameter
+- Changed the function signature of `utils/networkUtils.mts` -> `startDevelopmentServer()` to accept the entrypoint function directly instead of an ES module object and a separate key to reference the entrypoint function
+- Added locale override parameters to functions that could take advantage of them:
+  - `utils/consoleUtils.mts` -> `getPerformanceLabel()`
+  - `utils/filesystemUtils.mts` -> `getHumanReadableFilesize()`
+  - `utils/timeUtils.mts` -> `getElapsedTimeFormatted()`
+
 ## 1.0.9
 
 - Update target Bun version to `1.1.2` to inherit Bun's types for `node:util` `styleText()`; the associated `global.d.ts` was removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/utils/consoleUtils.mts
+++ b/utils/consoleUtils.mts
@@ -4,6 +4,9 @@ import { styleText } from 'node:util';
 // Internal Imports
 import { getElapsedTimeFormatted } from './timeUtils.mts';
 
+// Local Types
+type GetPerformanceLabelParameters = Parameters<typeof getElapsedTimeFormatted>;
+
 // Local Functions
 function cyan(text: string) {
   return styleText('cyan', text);
@@ -29,8 +32,12 @@ function yellow(text: string) {
   return styleText('yellow', text);
 }
 
-function getPerformanceLabel(startTime: number) {
-  const formattedTime = getElapsedTimeFormatted(startTime);
+function getPerformanceLabel(
+  startTime: GetPerformanceLabelParameters[0],
+  exactUnits?: GetPerformanceLabelParameters[1],
+  localeOverride?: GetPerformanceLabelParameters[2],
+) {
+  const formattedTime = getElapsedTimeFormatted(startTime, exactUnits, localeOverride);
   return dim(white(`[${formattedTime}]`));
 }
 

--- a/utils/consoleUtils.mts
+++ b/utils/consoleUtils.mts
@@ -5,7 +5,7 @@ import { styleText } from 'node:util';
 import { getElapsedTimeFormatted } from './timeUtils.mts';
 
 // Local Types
-type GetPerformanceLabelParameters = Parameters<typeof getElapsedTimeFormatted>;
+type GetElapsedTimeFormattedParameters = Parameters<typeof getElapsedTimeFormatted>;
 
 // Local Functions
 function cyan(text: string) {
@@ -33,9 +33,9 @@ function yellow(text: string) {
 }
 
 function getPerformanceLabel(
-  startTime: GetPerformanceLabelParameters[0],
-  exactUnits?: GetPerformanceLabelParameters[1],
-  localeOverride?: GetPerformanceLabelParameters[2],
+  startTime: GetElapsedTimeFormattedParameters[0],
+  exactUnits?: GetElapsedTimeFormattedParameters[1],
+  localeOverride?: GetElapsedTimeFormattedParameters[2],
 ) {
   const formattedTime = getElapsedTimeFormatted(startTime, exactUnits, localeOverride);
   return dim(white(`[${formattedTime}]`));

--- a/utils/filesystemUtils.mts
+++ b/utils/filesystemUtils.mts
@@ -24,7 +24,7 @@ async function getFilesRecursive(
   return recursiveEntries.flat(Number.POSITIVE_INFINITY).filter(Boolean) as string[];
 }
 
-function getHumanReadableFilesize(filesize: number) {
+function getHumanReadableFilesize(filesize: number, localeOverride?: string) {
   let divisionCount = 0;
   const divisor = 1_024;
   let humanReadableFilesize = filesize;
@@ -32,7 +32,7 @@ function getHumanReadableFilesize(filesize: number) {
     humanReadableFilesize /= divisor;
     divisionCount += 1;
   }
-  const localizedSize = humanReadableFilesize.toLocaleString(undefined, {
+  const localizedSize = humanReadableFilesize.toLocaleString(localeOverride, {
     maximumFractionDigits: 2,
     minimumFractionDigits: 0,
   });
@@ -42,7 +42,7 @@ function getHumanReadableFilesize(filesize: number) {
 
 async function isDirectoryAccessible(path: string) {
   try {
-    // eslint-disable-next-line no-bitwise -- following the documentation for fs constants: https://nodejs.org/docs/latest-v16.x/api/fs.html#fspromisesaccesspath-mode
+    // eslint-disable-next-line no-bitwise -- following the documentation for fs constants: https://nodejs.org/docs/latest/api/fs.html#fspromisesaccesspath-mode
     await access(path, fs.constants.R_OK | fs.constants.X_OK);
     return true;
   } catch {

--- a/utils/timeUtils.mts
+++ b/utils/timeUtils.mts
@@ -8,7 +8,11 @@ const timeUnits = ['ns', 'μs', 'ms', 's'] as const;
 type TimeUnits = (typeof timeUnits)[number];
 
 // Local Functions
-function getElapsedTimeFormatted(startTime: number, exactUnits: TimeUnits | '' = 'ms') {
+function getElapsedTimeFormatted(
+  startTime: number,
+  exactUnits: TimeUnits | '' = 'ms', // eslint-disable-line default-param-last -- localeOverride is also optional
+  localeOverride?: string,
+) {
   const endTime = nanoseconds();
   let elapsedTime = endTime - startTime;
   let timeIndex = 0;
@@ -29,7 +33,7 @@ function getElapsedTimeFormatted(startTime: number, exactUnits: TimeUnits | '' =
     }
   }
 
-  const elapsedTimeLocalized = elapsedTime.toLocaleString(undefined, {
+  const elapsedTimeLocalized = elapsedTime.toLocaleString(localeOverride, {
     maximumFractionDigits: 2,
     minimumFractionDigits: 2,
   });


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in [`package.json`](/package.json) following [Semantic Versioning](http://semver.org/)

**Changes Included**

- Version bump to `1.1.0`
- Added additional functionality to `utils/networkUtils.mts` -> `startDevelopmentServer()`
  - HTTPS serving with optional custom hostname support
  - Using any option that `Bun.serve()` accepts via an override parameter
- Changed the function signature of `utils/networkUtils.mts` -> `startDevelopmentServer()` to accept the entrypoint function directly instead of an ES module object and a separate key to reference the entrypoint function
- Added locale override parameters to functions that could take advantage of them:
  - `utils/consoleUtils.mts` -> `getPerformanceLabel()`
  - `utils/filesystemUtils.mts` -> `getHumanReadableFilesize()`
  - `utils/timeUtils.mts` -> `getElapsedTimeFormatted()`