### PR TITLE
Bug fixes for `utils/networkUtils.mts` -> `startDevelopmentServer()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.1
+
+- Bug fixes for `utils/networkUtils.mts` -> `startDevelopmentServer()`
+  - Show an error if the either the HTTPS `certificate` or `privateKey` fields do not point to a file
+  - Fix `optionOverrides` field not allowing most fields to be used
+
 ## 1.1.0
 
 - Added additional functionality to `utils/networkUtils.mts` -> `startDevelopmentServer()`

--- a/scripts/bun/startDevelopmentServer.mts
+++ b/scripts/bun/startDevelopmentServer.mts
@@ -40,7 +40,7 @@ async function main() {
     const modulePath = getOption<typeof values>(values, 'module-path');
     const module = (await import(modulePath)) as Record<string, FunctionSignature>;
     const entrypointFunction = module[functionName];
-    startDevelopmentServer(entrypointFunction!);
+    await startDevelopmentServer(entrypointFunction!);
   } catch (error) {
     if (error instanceof ReferenceError) {
       printError(error.message);


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in [`package.json`](/package.json) following [Semantic Versioning](http://semver.org/)

**Changes Included**

- Version bump to `1.1.1`
- Bug fixes for `utils/networkUtils.mts` -> `startDevelopmentServer()`
  - Show an error if the either the HTTPS `certificate` or `privateKey` fields do not point to a file
  - Fix `optionOverrides` field not allowing most fields to be used