### PR TITLE
Fix HTTPS error `OpenSSL NO_START_LINE` in `utils/networkUtils.mts` -> `startDevelopmentServer()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.3
+
+- Fix HTTPS error `OpenSSL NO_START_LINE` in `utils/networkUtils.mts` -> `startDevelopmentServer()`
+
 ## 1.1.2
 
 - Reduce confusion and possibility for errors by removing option overrides from `utils/networkUtils.mts` -> `startDevelopmentServer()`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/utils/networkUtils.mts
+++ b/utils/networkUtils.mts
@@ -1,7 +1,7 @@
 // External Imports
 import { access, constants } from 'node:fs/promises';
 import { format } from 'node:util';
-import { nanoseconds, serve, stringWidth } from 'bun';
+import { file, nanoseconds, serve, stringWidth } from 'bun';
 
 // Internal Imports
 import { cyan, dim, green, printError, red, yellow } from './consoleUtils.mts';
@@ -89,8 +89,8 @@ async function startDevelopmentServer(
 
     serverOptions.port = process.env.DEVELOPMENT_SERVER_PORT ?? 443;
     serverOptions.tls = {
-      cert: certificate,
-      key: privateKey,
+      cert: file(certificate),
+      key: file(privateKey),
     };
     if (hostname) {
       serverOptions.hostname = hostname;


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in [`package.json`](/package.json) following [Semantic Versioning](http://semver.org/)

**Changes Included**

- Version bump to `1.1.3`
- Fix HTTPS error `OpenSSL NO_START_LINE` in `utils/networkUtils.mts` -> `startDevelopmentServer()`