### PR TITLE
Add more HTTPS options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.2.0
+
+- Add more HTTPS options
+  - `certificateAuthority` for a custom certificate authority
+  - `diffieHellmanParametersPath` to customize Diffie Hellman parameters
+  - `passphrase` to provide the passphrase used to create a TLS certificate
+- Decouple hostname from HTTPS options
+- Improve error messaging when HTTPS configuration files cannot be loaded
+- Ensure process termination when an HTTPS configuration file cannot be loaded
+- Display server options when `DEBUG` environment variable is set to a truthy value
+
 ## 1.1.3
 
 - Fix HTTPS error `OpenSSL NO_START_LINE` in `utils/networkUtils.mts` -> `startDevelopmentServer()`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in [`package.json`](/package.json) following [Semantic Versioning](http://semver.org/)

**Changes Included**

- Version bump to `1.2.0`
- Add more HTTPS options
  - `certificateAuthority` for a custom certificate authority
  - `diffieHellmanParametersPath` to customize Diffie Hellman parameters
  - `passphrase` to provide the passphrase used to create a TLS certificate
- Decouple hostname from HTTPS options
- Improve error messaging when HTTPS configuration files cannot be loaded
- Ensure process termination when an HTTPS configuration file cannot be loaded
- Display server options when `DEBUG` environment variable is set to a truthy value