### PR TITLE
Changed the function signature of `utils/networkUtils.mts` -> `startDevelopmentServer()` to accept a single configuration object instead of multiple configuration parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.1.0
+
+- Changed the function signature of `utils/networkUtils.mts` -> `startDevelopmentServer()` to accept a single configuration object instead of multiple configuration parameters
+  - Documentation updated
+- Disabled rule `jsdoc/check-line-alignment`
+- Disabled JSDoc parameter expansion so parameters are more clearly shown; type information now only lives in parameter detail tables
+
 ## 2.0.3
 
 - Enable links to source code in documentation

--- a/config/eslint/eslintConfig.json
+++ b/config/eslint/eslintConfig.json
@@ -10,7 +10,6 @@
     "import/core-modules": ["bun"]
   },
   "rules": {
-    "jsdoc/check-line-alignment": ["error", "always"],
     "jsdoc/multiline-blocks": ["error", { "noSingleLineBlocks": true }],
     "jsdoc/no-bad-blocks": "error",
     "jsdoc/require-asterisk-prefix": "error",

--- a/config/typedoc/typedoc.json
+++ b/config/typedoc/typedoc.json
@@ -4,7 +4,7 @@
   "disableSources": false,
   "entryPoints": ["../../utils/**/*.mts"],
   "enumMembersFormat": "table",
-  "expandParameters": true,
+  "expandParameters": false,
   "githubPages": false,
   "hideBreadcrumbs": true,
   "hidePageHeader": true,

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -21,4 +21,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/buildUtils.mts#L25)
+[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/buildUtils.mts#L25)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -4,7 +4,7 @@
 
 ### printBuildMetadata()
 
-> **printBuildMetadata**(`buildOutput`: `BuildOutput`, `buildOutputDirectory`: `string`): `void`
+> **printBuildMetadata**(`buildOutput`, `buildOutputDirectory`): `void`
 
 Format and print to the command line the provided build metadata.
 
@@ -21,4 +21,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/buildUtils.mts#L25)
+[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/buildUtils.mts#L25)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -4,7 +4,7 @@
 
 ### cyan()
 
-> **cyan**(`text`: `string`): `string`
+> **cyan**(`text`): `string`
 
 Format the text so it appears cyan.
 
@@ -22,13 +22,13 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/consoleUtils.mts#L20)
+[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L20)
 
 ***
 
 ### dim()
 
-> **dim**(`text`: `string`): `string`
+> **dim**(`text`): `string`
 
 Format the text so it appears dim.
 
@@ -46,13 +46,13 @@ Text formatted so it appears dim.
 
 #### Source
 
-[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/consoleUtils.mts#L29)
+[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L29)
 
 ***
 
 ### getPerformanceLabel()
 
-> **getPerformanceLabel**(`startTime`: `number`, `unitsOverride`?: `""` \| `"ns"` \| `"μs"` \| `"ms"` \| `"s"`, `localeOverride`?: `string`): `string`
+> **getPerformanceLabel**(`startTime`, `unitsOverride`?, `localeOverride`?): `string`
 
 Get a text label showing the elapsed time between the provided start time parameter and the time
 the function is called. Optionally the time units and formatting locale can be overridden.
@@ -73,13 +73,13 @@ A localized text label showing elapsed time with units.
 
 #### Source
 
-[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/consoleUtils.mts#L78)
+[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L78)
 
 ***
 
 ### green()
 
-> **green**(`text`: `string`): `string`
+> **green**(`text`): `string`
 
 Format the text so it appears green.
 
@@ -97,13 +97,13 @@ Text formatted so it appears green.
 
 #### Source
 
-[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/consoleUtils.mts#L38)
+[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L38)
 
 ***
 
 ### printError()
 
-> **printError**(`message`: `string`): `void`
+> **printError**(`message`): `void`
 
 Print an error message to the console in red.
 
@@ -119,13 +119,13 @@ Print an error message to the console in red.
 
 #### Source
 
-[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/consoleUtils.mts#L91)
+[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L91)
 
 ***
 
 ### printInfo()
 
-> **printInfo**(`message`: `string`): `void`
+> **printInfo**(`message`): `void`
 
 Print an informational message to the console in cyan.
 
@@ -141,13 +141,13 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/consoleUtils.mts#L99)
+[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L99)
 
 ***
 
 ### printSuccess()
 
-> **printSuccess**(`message`: `string`): `void`
+> **printSuccess**(`message`): `void`
 
 Print a success message to the console in green.
 
@@ -163,13 +163,13 @@ Print a success message to the console in green.
 
 #### Source
 
-[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/consoleUtils.mts#L107)
+[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L107)
 
 ***
 
 ### printWarning()
 
-> **printWarning**(`message`: `string`): `void`
+> **printWarning**(`message`): `void`
 
 Print a warning message to the console in yellow.
 
@@ -185,13 +185,13 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/consoleUtils.mts#L115)
+[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L115)
 
 ***
 
 ### red()
 
-> **red**(`text`: `string`): `string`
+> **red**(`text`): `string`
 
 Format the text so it appears red.
 
@@ -209,13 +209,13 @@ Text formatted so it appears red.
 
 #### Source
 
-[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/consoleUtils.mts#L47)
+[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L47)
 
 ***
 
 ### white()
 
-> **white**(`text`: `string`): `string`
+> **white**(`text`): `string`
 
 Format the text so it appears white.
 
@@ -233,13 +233,13 @@ Text formatted so it appears white.
 
 #### Source
 
-[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/consoleUtils.mts#L56)
+[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L56)
 
 ***
 
 ### yellow()
 
-> **yellow**(`text`: `string`): `string`
+> **yellow**(`text`): `string`
 
 Format the text so it appears yellow.
 
@@ -257,4 +257,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/consoleUtils.mts#L65)
+[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L65)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L20)
+[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/consoleUtils.mts#L20)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L29)
+[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/consoleUtils.mts#L29)
 
 ***
 
@@ -73,7 +73,7 @@ A localized text label showing elapsed time with units.
 
 #### Source
 
-[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L78)
+[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/consoleUtils.mts#L78)
 
 ***
 
@@ -97,7 +97,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L38)
+[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/consoleUtils.mts#L38)
 
 ***
 
@@ -119,7 +119,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L91)
+[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/consoleUtils.mts#L91)
 
 ***
 
@@ -141,7 +141,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L99)
+[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/consoleUtils.mts#L99)
 
 ***
 
@@ -163,7 +163,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L107)
+[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/consoleUtils.mts#L107)
 
 ***
 
@@ -185,7 +185,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L115)
+[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/consoleUtils.mts#L115)
 
 ***
 
@@ -209,7 +209,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L47)
+[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/consoleUtils.mts#L47)
 
 ***
 
@@ -233,7 +233,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L56)
+[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/consoleUtils.mts#L56)
 
 ***
 
@@ -257,4 +257,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/consoleUtils.mts#L65)
+[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/consoleUtils.mts#L65)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -23,7 +23,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/filesystemUtils.mts#L18)
+[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/filesystemUtils.mts#L18)
 
 ***
 
@@ -48,7 +48,7 @@ A localized string representing a file size.
 
 #### Source
 
-[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/filesystemUtils.mts#L60)
+[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/filesystemUtils.mts#L60)
 
 ***
 
@@ -74,7 +74,7 @@ A list of paths.
 
 #### Source
 
-[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/filesystemUtils.mts#L36)
+[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/filesystemUtils.mts#L36)
 
 ***
 
@@ -98,4 +98,4 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/filesystemUtils.mts#L81)
+[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/filesystemUtils.mts#L81)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -4,7 +4,7 @@
 
 ### findMissingPaths()
 
-> **findMissingPaths**(`paths`: `string`[]): `Promise`\<`string`[]\>
+> **findMissingPaths**(`paths`): `Promise`\<`string`[]\>
 
 Compile a list of all inaccessible file paths, then return it. If all paths are valid, the list
 will be empty.
@@ -23,13 +23,13 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/filesystemUtils.mts#L18)
+[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/filesystemUtils.mts#L18)
 
 ***
 
 ### getHumanReadableFilesize()
 
-> **getHumanReadableFilesize**(`filesize`: `number`, `localeOverride`?: `string`): `string`
+> **getHumanReadableFilesize**(`filesize`, `localeOverride`?): `string`
 
 Get a human readable filesize given its numeric value and an optional locale.
 
@@ -48,13 +48,13 @@ A localized string representing a file size.
 
 #### Source
 
-[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/filesystemUtils.mts#L60)
+[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/filesystemUtils.mts#L60)
 
 ***
 
 ### getPathsRecursive()
 
-> **getPathsRecursive**(`rootDirectory`: `string`, `ignore`: `string`[]): `Promise`\<`string`[]\>
+> **getPathsRecursive**(`rootDirectory`, `ignore`): `Promise`\<`string`[]\>
 
 Recursively build a list of paths starting at a target directory. Ignore any paths that match
 values in the included ignore list.
@@ -74,13 +74,13 @@ A list of paths.
 
 #### Source
 
-[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/filesystemUtils.mts#L36)
+[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/filesystemUtils.mts#L36)
 
 ***
 
 ### isDirectoryAccessible()
 
-> **isDirectoryAccessible**(`path`: `string`): `Promise`\<`boolean`\>
+> **isDirectoryAccessible**(`path`): `Promise`\<`boolean`\>
 
 Determine if the provided path can be successfully accessed.
 
@@ -98,4 +98,4 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/filesystemUtils.mts#L81)
+[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/filesystemUtils.mts#L81)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -34,4 +34,4 @@ Multiple server instances can be started simultaneously with unique port values.
 
 #### Source
 
-[networkUtils.mts:96](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/networkUtils.mts#L96)
+[networkUtils.mts:96](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/networkUtils.mts#L96)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -4,18 +4,29 @@
 
 ### startDevelopmentServer()
 
-> **startDevelopmentServer**(`entrypointFunction`: (`request`: `Request`) => `Response` \| `Promise`\<`Response`\>, `hostname`?: `string`, `httpsOptions`?: `HttpsOptions`): `Promise`\<`void`\>
+> **startDevelopmentServer**(`entrypointFunction`, `serverConfiguration`): `Promise`\<`void`\>
 
 Start a development server using Bun.serve() and the provided entrypoint function. Optionally
-specify a hostname and options for enabling HTTPS-based serving.
+specify a configuration object to customize functionality as follows:
+\{
+  hostname?: string;
+  httpsOptions?: \{
+    certificate: string;
+    certificateAuthority?: string;
+    diffieHellmanParametersPath?: string;
+    passphrase?: string;
+    privateKey: string;
+  \}
+  port?: number;
+\}
+Multiple server instances can be started simultaneously with unique port values.
 
 #### Parameters
 
 | Parameter | Type | Description |
 | :------ | :------ | :------ |
-| `entrypointFunction` | (`request`: `Request`) => `Response` \| `Promise`\<`Response`\> | The function used to start running the server. |
-| `hostname`? | `string` | An optional hostname upon which to listen. |
-| `httpsOptions`? | `HttpsOptions` | An optional configuration set to enable HTTPS-based serving. |
+| `entrypointFunction` | (`request`) => `Response` \| `Promise`\<`Response`\> | The function used to start running the server. |
+| `serverConfiguration` | `ServerConfiguration` | An optional configuration object. |
 
 #### Returns
 
@@ -23,4 +34,4 @@ specify a hostname and options for enabling HTTPS-based serving.
 
 #### Source
 
-[networkUtils.mts:79](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/networkUtils.mts#L79)
+[networkUtils.mts:96](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/networkUtils.mts#L96)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -4,7 +4,7 @@
 
 ### getElapsedTimeFormatted()
 
-> **getElapsedTimeFormatted**(`startTime`: `number`, `unitsOverride`: `""` \| `"ns"` \| `"μs"` \| `"ms"` \| `"s"`, `localeOverride`?: `string`): `string`
+> **getElapsedTimeFormatted**(`startTime`, `unitsOverride`, `localeOverride`?): `string`
 
 Get a formatted string representing the time between the provided start time parameter and the
 time the function is called. Optionally the time units and formatting locale can be overridden.
@@ -25,4 +25,4 @@ A localized string showing elapsed time with units.
 
 #### Source
 
-[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/0e63ba4ba81750eee704bec08236136074bb0b97/utils/timeUtils.mts#L24)
+[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/timeUtils.mts#L24)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -25,4 +25,4 @@ A localized string showing elapsed time with units.
 
 #### Source
 
-[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/44e9c57a5b260e4350f55bdadcc61e3921aa4e12/utils/timeUtils.mts#L24)
+[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/eaf95930611d600fac9bac2f9ec5571b46193fb2/utils/timeUtils.mts#L24)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)

**Changes Included**

- Version bump to `2.1.0
- Changed the function signature of `utils/networkUtils.mts` -> `startDevelopmentServer()` to accept a single configuration object instead of multiple configuration parameters
  - Documentation updated
- Disabled rule `jsdoc/check-line-alignment`
- Disabled JSDoc parameter expansion so parameters are more clearly shown; type information now only lives in parameter detail tables