### PR TITLE
Add documentation how configuration options map back to those in `Bun.serve()` in `utils/networkUtils.mts` -> `startDevelopmentServer()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.2
+
+- Add documentation how configuration options map back to those in `Bun.serve()` in `utils/networkUtils.mts` -> `startDevelopmentServer()`
+
 ## 2.2.1
 
 - Document default values for `port` configuration option in `utils/networkUtils.mts` -> `startDevelopmentServer()`

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -21,4 +21,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/buildUtils.mts#L25)
+[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/buildUtils.mts#L25)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -21,4 +21,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/buildUtils.mts#L25)
+[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/buildUtils.mts#L25)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L20)
+[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/consoleUtils.mts#L20)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L29)
+[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/consoleUtils.mts#L29)
 
 ***
 
@@ -73,7 +73,7 @@ A localized text label showing elapsed time with units.
 
 #### Source
 
-[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L78)
+[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/consoleUtils.mts#L78)
 
 ***
 
@@ -97,7 +97,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L38)
+[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/consoleUtils.mts#L38)
 
 ***
 
@@ -119,7 +119,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L91)
+[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/consoleUtils.mts#L91)
 
 ***
 
@@ -141,7 +141,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L99)
+[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/consoleUtils.mts#L99)
 
 ***
 
@@ -163,7 +163,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L107)
+[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/consoleUtils.mts#L107)
 
 ***
 
@@ -185,7 +185,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L115)
+[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/consoleUtils.mts#L115)
 
 ***
 
@@ -209,7 +209,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L47)
+[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/consoleUtils.mts#L47)
 
 ***
 
@@ -233,7 +233,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L56)
+[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/consoleUtils.mts#L56)
 
 ***
 
@@ -257,4 +257,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L65)
+[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/consoleUtils.mts#L65)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/consoleUtils.mts#L20)
+[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L20)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/consoleUtils.mts#L29)
+[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L29)
 
 ***
 
@@ -73,7 +73,7 @@ A localized text label showing elapsed time with units.
 
 #### Source
 
-[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/consoleUtils.mts#L78)
+[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L78)
 
 ***
 
@@ -97,7 +97,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/consoleUtils.mts#L38)
+[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L38)
 
 ***
 
@@ -119,7 +119,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/consoleUtils.mts#L91)
+[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L91)
 
 ***
 
@@ -141,7 +141,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/consoleUtils.mts#L99)
+[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L99)
 
 ***
 
@@ -163,7 +163,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/consoleUtils.mts#L107)
+[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L107)
 
 ***
 
@@ -185,7 +185,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/consoleUtils.mts#L115)
+[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L115)
 
 ***
 
@@ -209,7 +209,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/consoleUtils.mts#L47)
+[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L47)
 
 ***
 
@@ -233,7 +233,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/consoleUtils.mts#L56)
+[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L56)
 
 ***
 
@@ -257,4 +257,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/consoleUtils.mts#L65)
+[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/consoleUtils.mts#L65)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -23,7 +23,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/filesystemUtils.mts#L18)
+[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/filesystemUtils.mts#L18)
 
 ***
 
@@ -48,7 +48,7 @@ A localized string representing a file size.
 
 #### Source
 
-[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/filesystemUtils.mts#L60)
+[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/filesystemUtils.mts#L60)
 
 ***
 
@@ -74,7 +74,7 @@ A list of paths.
 
 #### Source
 
-[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/filesystemUtils.mts#L36)
+[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/filesystemUtils.mts#L36)
 
 ***
 
@@ -98,4 +98,4 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/filesystemUtils.mts#L81)
+[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/filesystemUtils.mts#L81)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -23,7 +23,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/filesystemUtils.mts#L18)
+[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/filesystemUtils.mts#L18)
 
 ***
 
@@ -48,7 +48,7 @@ A localized string representing a file size.
 
 #### Source
 
-[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/filesystemUtils.mts#L60)
+[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/filesystemUtils.mts#L60)
 
 ***
 
@@ -74,7 +74,7 @@ A list of paths.
 
 #### Source
 
-[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/filesystemUtils.mts#L36)
+[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/filesystemUtils.mts#L36)
 
 ***
 
@@ -98,4 +98,4 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/filesystemUtils.mts#L81)
+[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/filesystemUtils.mts#L81)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -10,15 +10,15 @@ Start a development server with the provided entrypoint function; uses `Bun.serv
 server. Optionally specify a configuration object to customize functionality as follows:
 ```ts
 {
-  hostname?: string; // Defaults to localhost
+  hostname?: string;                              // Defaults to localhost
   httpsOptions?: {
-    certificatePath: string | string[];
-    certificateAuthorityPath?: string | string[];
-    diffieHellmanParametersPath?: string;
-    passphrase?: string;
-    privateKeyPath: string | string[];
+    certificatePath: string | string[];           // Maps to `Bun.serve()`'s tls.cert option
+    certificateAuthorityPath?: string | string[]; // Maps to `Bun.serve()`'s tls.ca option
+    diffieHellmanParametersPath?: string;         // Maps to `Bun.serve()`'s tls.dhParamsFile option
+    passphrase?: string;                          // Maps to `Bun.serve()`'s tls.passphrase option
+    privateKeyPath: string | string[];            // Maps to `Bun.serve()`'s tls.key option
   };
-  port?: string | number; // Defaults to process.env.DEVELOPMENT_SERVER_PORT else 3_000 for HTTP, 443 for HTTPS
+  port?: string | number;                         // Defaults to process.env.DEVELOPMENT_SERVER_PORT else 3_000 for HTTP, 443 for HTTPS
 ```
 **NOTE:** multiple server instances can be started simultaneously with unique port values.
 
@@ -35,4 +35,4 @@ server. Optionally specify a configuration object to customize functionality as 
 
 #### Source
 
-[networkUtils.mts:97](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/networkUtils.mts#L97)
+[networkUtils.mts:97](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/networkUtils.mts#L97)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -12,11 +12,11 @@ server. Optionally specify a configuration object to customize functionality as 
 {
   hostname?: string;                              // Defaults to localhost
   httpsOptions?: {
-    certificatePath: string | string[];           // Maps to `Bun.serve()`'s tls.cert option
-    certificateAuthorityPath?: string | string[]; // Maps to `Bun.serve()`'s tls.ca option
-    diffieHellmanParametersPath?: string;         // Maps to `Bun.serve()`'s tls.dhParamsFile option
-    passphrase?: string;                          // Maps to `Bun.serve()`'s tls.passphrase option
-    privateKeyPath: string | string[];            // Maps to `Bun.serve()`'s tls.key option
+    certificatePath: string | string[];           // Maps to Bun.serve()'s tls.cert option
+    certificateAuthorityPath?: string | string[]; // Maps to Bun.serve()'s tls.ca option
+    diffieHellmanParametersPath?: string;         // Maps to Bun.serve()'s tls.dhParamsFile option
+    passphrase?: string;                          // Maps to Bun.serve()'s tls.passphrase option
+    privateKeyPath: string | string[];            // Maps to Bun.serve()'s tls.key option
   };
   port?: string | number;                         // Defaults to process.env.DEVELOPMENT_SERVER_PORT else 3_000 for HTTP, 443 for HTTPS
 ```
@@ -35,4 +35,4 @@ server. Optionally specify a configuration object to customize functionality as 
 
 #### Source
 
-[networkUtils.mts:97](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/networkUtils.mts#L97)
+[networkUtils.mts:97](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/networkUtils.mts#L97)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -25,4 +25,4 @@ A localized string showing elapsed time with units.
 
 #### Source
 
-[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/17f518865af5fccd197907b90a62cc9ee7778b9c/utils/timeUtils.mts#L24)
+[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/timeUtils.mts#L24)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -25,4 +25,4 @@ A localized string showing elapsed time with units.
 
 #### Source
 
-[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/f4668b5e67076053e5580155caf3b7c5e6397517/utils/timeUtils.mts#L24)
+[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/2806ff839dd7f6d4d485d46bc5e961d6e91f5578/utils/timeUtils.mts#L24)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/utils/networkUtils.mts
+++ b/utils/networkUtils.mts
@@ -82,11 +82,11 @@ function logServerStartup({ url: { href } }: Server) {
  * {
  *   hostname?: string;                              // Defaults to localhost
  *   httpsOptions?: {
- *     certificatePath: string | string[];           // Maps to `Bun.serve()`'s tls.cert option
- *     certificateAuthorityPath?: string | string[]; // Maps to `Bun.serve()`'s tls.ca option
- *     diffieHellmanParametersPath?: string;         // Maps to `Bun.serve()`'s tls.dhParamsFile option
- *     passphrase?: string;                          // Maps to `Bun.serve()`'s tls.passphrase option
- *     privateKeyPath: string | string[];            // Maps to `Bun.serve()`'s tls.key option
+ *     certificatePath: string | string[];           // Maps to Bun.serve()'s tls.cert option
+ *     certificateAuthorityPath?: string | string[]; // Maps to Bun.serve()'s tls.ca option
+ *     diffieHellmanParametersPath?: string;         // Maps to Bun.serve()'s tls.dhParamsFile option
+ *     passphrase?: string;                          // Maps to Bun.serve()'s tls.passphrase option
+ *     privateKeyPath: string | string[];            // Maps to Bun.serve()'s tls.key option
  *   };
  *   port?: string | number;                         // Defaults to process.env.DEVELOPMENT_SERVER_PORT else 3_000 for HTTP, 443 for HTTPS
  * ```

--- a/utils/networkUtils.mts
+++ b/utils/networkUtils.mts
@@ -80,15 +80,15 @@ function logServerStartup({ url: { href } }: Server) {
  * server. Optionally specify a configuration object to customize functionality as follows:
  * ```ts
  * {
- *   hostname?: string; // Defaults to localhost
+ *   hostname?: string;                              // Defaults to localhost
  *   httpsOptions?: {
- *     certificatePath: string | string[];
- *     certificateAuthorityPath?: string | string[];
- *     diffieHellmanParametersPath?: string;
- *     passphrase?: string;
- *     privateKeyPath: string | string[];
+ *     certificatePath: string | string[];           // Maps to `Bun.serve()`'s tls.cert option
+ *     certificateAuthorityPath?: string | string[]; // Maps to `Bun.serve()`'s tls.ca option
+ *     diffieHellmanParametersPath?: string;         // Maps to `Bun.serve()`'s tls.dhParamsFile option
+ *     passphrase?: string;                          // Maps to `Bun.serve()`'s tls.passphrase option
+ *     privateKeyPath: string | string[];            // Maps to `Bun.serve()`'s tls.key option
  *   };
- *   port?: string | number; // Defaults to process.env.DEVELOPMENT_SERVER_PORT else 3_000 for HTTP, 443 for HTTPS
+ *   port?: string | number;                         // Defaults to process.env.DEVELOPMENT_SERVER_PORT else 3_000 for HTTP, 443 for HTTPS
  * ```
  * **NOTE:** multiple server instances can be started simultaneously with unique port values.
  * @param entrypointFunction  The function used to start running the server.


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)

**Changes Included**

- Version bump to `2.2.2`
- Add documentation how configuration options map back to those in `Bun.serve()` in `utils/networkUtils.mts` -> `startDevelopmentServer()`