### PR TITLE
Fix bug in the `Router` class in `utils/networkUtils.mts` so calling a lazy-loaded route handler function works correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.1
+
+- Fix bug in the `Router` class in `utils/networkUtils.mts` so calling a lazy-loaded route handler function works correctly
+
 ## 2.4.0
 
 - Add lazy-loaded route handler support to the `Router` class in `utils/networkUtils.mts`

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -21,4 +21,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/buildUtils.mts#L25)
+[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/buildUtils.mts#L25)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/consoleUtils.mts#L20)
+[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/consoleUtils.mts#L20)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/consoleUtils.mts#L29)
+[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/consoleUtils.mts#L29)
 
 ***
 
@@ -73,7 +73,7 @@ A localized text label showing elapsed time with units.
 
 #### Source
 
-[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/consoleUtils.mts#L78)
+[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/consoleUtils.mts#L78)
 
 ***
 
@@ -97,7 +97,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/consoleUtils.mts#L38)
+[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/consoleUtils.mts#L38)
 
 ***
 
@@ -119,7 +119,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/consoleUtils.mts#L91)
+[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/consoleUtils.mts#L91)
 
 ***
 
@@ -141,7 +141,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/consoleUtils.mts#L99)
+[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/consoleUtils.mts#L99)
 
 ***
 
@@ -163,7 +163,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/consoleUtils.mts#L107)
+[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/consoleUtils.mts#L107)
 
 ***
 
@@ -185,7 +185,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/consoleUtils.mts#L115)
+[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/consoleUtils.mts#L115)
 
 ***
 
@@ -209,7 +209,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/consoleUtils.mts#L47)
+[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/consoleUtils.mts#L47)
 
 ***
 
@@ -233,7 +233,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/consoleUtils.mts#L56)
+[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/consoleUtils.mts#L56)
 
 ***
 
@@ -257,4 +257,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/consoleUtils.mts#L65)
+[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/consoleUtils.mts#L65)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -23,7 +23,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/filesystemUtils.mts#L18)
+[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/filesystemUtils.mts#L18)
 
 ***
 
@@ -48,7 +48,7 @@ A localized string representing a file size.
 
 #### Source
 
-[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/filesystemUtils.mts#L60)
+[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/filesystemUtils.mts#L60)
 
 ***
 
@@ -74,7 +74,7 @@ A list of paths.
 
 #### Source
 
-[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/filesystemUtils.mts#L36)
+[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/filesystemUtils.mts#L36)
 
 ***
 
@@ -98,4 +98,4 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/filesystemUtils.mts#L81)
+[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/filesystemUtils.mts#L81)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -16,7 +16,7 @@
 
 ###### Source
 
-[networkUtils.mts:219](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/networkUtils.mts#L219)
+[networkUtils.mts:219](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/networkUtils.mts#L219)
 
 #### Properties
 
@@ -44,7 +44,7 @@
 
 ###### Source
 
-[networkUtils.mts:258](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/networkUtils.mts#L258)
+[networkUtils.mts:262](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/networkUtils.mts#L262)
 
 ##### delete()
 
@@ -63,7 +63,7 @@
 
 ###### Source
 
-[networkUtils.mts:266](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/networkUtils.mts#L266)
+[networkUtils.mts:270](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/networkUtils.mts#L270)
 
 ##### get()
 
@@ -82,11 +82,11 @@
 
 ###### Source
 
-[networkUtils.mts:270](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/networkUtils.mts#L270)
+[networkUtils.mts:274](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/networkUtils.mts#L274)
 
 ##### init()
 
-> **init**(`request`): `Promise`\<`undefined` \| `Response` \| `RouteHandlerFunction`\>
+> **init**(`request`): `Promise`\<`Response`\>
 
 ###### Parameters
 
@@ -96,11 +96,11 @@
 
 ###### Returns
 
-`Promise`\<`undefined` \| `Response` \| `RouteHandlerFunction`\>
+`Promise`\<`Response`\>
 
 ###### Source
 
-[networkUtils.mts:239](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/networkUtils.mts#L239)
+[networkUtils.mts:239](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/networkUtils.mts#L239)
 
 ##### patch()
 
@@ -119,7 +119,7 @@
 
 ###### Source
 
-[networkUtils.mts:274](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/networkUtils.mts#L274)
+[networkUtils.mts:278](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/networkUtils.mts#L278)
 
 ##### post()
 
@@ -138,7 +138,7 @@
 
 ###### Source
 
-[networkUtils.mts:278](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/networkUtils.mts#L278)
+[networkUtils.mts:282](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/networkUtils.mts#L282)
 
 ##### put()
 
@@ -157,7 +157,7 @@
 
 ###### Source
 
-[networkUtils.mts:282](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/networkUtils.mts#L282)
+[networkUtils.mts:286](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/networkUtils.mts#L286)
 
 ## Functions
 
@@ -197,4 +197,4 @@ Optionally specify a configuration object to customize functionality as follows:
 
 #### Source
 
-[networkUtils.mts:122](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/networkUtils.mts#L122)
+[networkUtils.mts:122](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/networkUtils.mts#L122)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -25,4 +25,4 @@ A localized string showing elapsed time with units.
 
 #### Source
 
-[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/1d0f7999385f4bb5b1f6352bb1eed49a200a26b1/utils/timeUtils.mts#L24)
+[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/ada05ebfefea10276299cbf8800d1892b132b005/utils/timeUtils.mts#L24)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/utils/networkUtils.mts
+++ b/utils/networkUtils.mts
@@ -246,9 +246,13 @@ class Router {
           if (typeof routeHandler === 'function') {
             return routeHandler(request);
           }
-          // eslint-disable-next-line no-await-in-loop -- this will only ever await once
-          const routeModule = await routeHandler.modulePromise;
-          return routeModule[routeHandler.moduleKey];
+          const { moduleKey, modulePromise } = routeHandler;
+          const routeModule = await modulePromise; // eslint-disable-line no-await-in-loop -- this will only ever await once
+          const targetFunction = routeModule[moduleKey];
+          if (typeof targetFunction === 'function') {
+            return targetFunction(request);
+          }
+          throw new TypeError(`Lazy-loaded route handler target "${moduleKey}" was not a function`);
         }
       }
     }


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)
- [x] (OPTIONAL) Build updated documentation using `package.json` script `build:documentation`

**Changes Included**

- Version bump to `2.4.1`
- Fix bug in the `Router` class in `utils/networkUtils.mts` so calling a lazy-loaded route handler function works correctly