### PR TITLE
Fix lazy loading route handlers to actually load lazily instead of eagerly (in `utils/routerUtils.mts`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.2
+
+- Fix lazy loading route handlers to actually load lazily instead of eagerly (in `utils/routerUtils.mts`)
+
 ## 2.6.1
 
 - Make `Router` instance `routes` array private (in `utils/routerUtils.mts`)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -21,4 +21,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/buildUtils.mts#L25)
+[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/buildUtils.mts#L25)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/consoleUtils.mts#L20)
+[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/consoleUtils.mts#L20)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/consoleUtils.mts#L29)
+[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/consoleUtils.mts#L29)
 
 ***
 
@@ -73,7 +73,7 @@ A localized text label showing elapsed time with units.
 
 #### Source
 
-[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/consoleUtils.mts#L78)
+[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/consoleUtils.mts#L78)
 
 ***
 
@@ -97,7 +97,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/consoleUtils.mts#L38)
+[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/consoleUtils.mts#L38)
 
 ***
 
@@ -119,7 +119,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/consoleUtils.mts#L91)
+[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/consoleUtils.mts#L91)
 
 ***
 
@@ -141,7 +141,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/consoleUtils.mts#L99)
+[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/consoleUtils.mts#L99)
 
 ***
 
@@ -163,7 +163,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/consoleUtils.mts#L107)
+[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/consoleUtils.mts#L107)
 
 ***
 
@@ -185,7 +185,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/consoleUtils.mts#L115)
+[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/consoleUtils.mts#L115)
 
 ***
 
@@ -209,7 +209,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/consoleUtils.mts#L47)
+[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/consoleUtils.mts#L47)
 
 ***
 
@@ -233,7 +233,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/consoleUtils.mts#L56)
+[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/consoleUtils.mts#L56)
 
 ***
 
@@ -257,4 +257,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/consoleUtils.mts#L65)
+[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/consoleUtils.mts#L65)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -23,7 +23,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/filesystemUtils.mts#L18)
+[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/filesystemUtils.mts#L18)
 
 ***
 
@@ -48,7 +48,7 @@ A localized string representing a file size.
 
 #### Source
 
-[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/filesystemUtils.mts#L60)
+[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/filesystemUtils.mts#L60)
 
 ***
 
@@ -74,7 +74,7 @@ A list of paths.
 
 #### Source
 
-[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/filesystemUtils.mts#L36)
+[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/filesystemUtils.mts#L36)
 
 ***
 
@@ -98,4 +98,4 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/filesystemUtils.mts#L81)
+[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/filesystemUtils.mts#L81)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -38,4 +38,4 @@ Optionally specify a configuration object to customize functionality as follows:
 
 #### Source
 
-[networkUtils.mts:99](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/networkUtils.mts#L99)
+[networkUtils.mts:99](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/networkUtils.mts#L99)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -34,7 +34,7 @@ Constructor that creates an empty array for route definitions.
 
 ###### Source
 
-[routerUtils.mts:51](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/routerUtils.mts#L51)
+[routerUtils.mts:51](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/routerUtils.mts#L51)
 
 #### Properties
 
@@ -66,7 +66,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:116](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/routerUtils.mts#L116)
+[routerUtils.mts:116](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/routerUtils.mts#L116)
 
 ##### all()
 
@@ -89,7 +89,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:130](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/routerUtils.mts#L130)
+[routerUtils.mts:130](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/routerUtils.mts#L130)
 
 ##### delete()
 
@@ -112,7 +112,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:140](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/routerUtils.mts#L140)
+[routerUtils.mts:140](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/routerUtils.mts#L140)
 
 ##### get()
 
@@ -135,7 +135,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:150](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/routerUtils.mts#L150)
+[routerUtils.mts:150](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/routerUtils.mts#L150)
 
 ##### handleRequest()
 
@@ -157,7 +157,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Source
 
-[routerUtils.mts:76](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/routerUtils.mts#L76)
+[routerUtils.mts:76](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/routerUtils.mts#L76)
 
 ##### head()
 
@@ -180,7 +180,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:160](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/routerUtils.mts#L160)
+[routerUtils.mts:160](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/routerUtils.mts#L160)
 
 ##### options()
 
@@ -203,7 +203,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/routerUtils.mts#L170)
+[routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/routerUtils.mts#L170)
 
 ##### patch()
 
@@ -226,7 +226,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:180](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/routerUtils.mts#L180)
+[routerUtils.mts:180](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/routerUtils.mts#L180)
 
 ##### post()
 
@@ -249,7 +249,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:190](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/routerUtils.mts#L190)
+[routerUtils.mts:190](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/routerUtils.mts#L190)
 
 ##### put()
 
@@ -272,4 +272,4 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:200](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/routerUtils.mts#L200)
+[routerUtils.mts:200](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/routerUtils.mts#L200)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -25,4 +25,4 @@ A localized string showing elapsed time with units.
 
 #### Source
 
-[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/345fb98ebe5f0a4cbd6e5874e045a5ffa407cc17/utils/timeUtils.mts#L24)
+[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/d23e080d00ad3069d730f262f13ace849cfff11e/utils/timeUtils.mts#L24)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)
- [x] (OPTIONAL) Build updated documentation using `package.json` script `build:documentation`

**Changes Included**

- Version bump to `2.6.2`
- Fix lazy loading route handlers to actually load lazily instead of eagerly (in `utils/routerUtils.mts`)