### PR TITLE
Multiple `Server-Timing` features added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.7.0
+
+- The `Router` now appends `Server-Timing` values for route loading duration to the request object's headers
+- Added new function `buildServerTimingHeader()` to create `Server-Timing` header values
+- Added new parameters to the `Router` constructor (in `utils/routerUtils.mts`)
+  - `startTime` is the start time of loading a route; used to compute `Server-Timing` duration.
+  - `usesServerTiming` is a boolean indicating if `Server-Timing` headers are sent or not
+
 ## 2.6.3
 
 - Update example usage for `Router` in the documentation (in `utils/routerUtils.mts`)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -21,4 +21,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/buildUtils.mts#L25)
+[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/buildUtils.mts#L25)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -21,4 +21,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/buildUtils.mts#L25)
+[buildUtils.mts:25](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/buildUtils.mts#L25)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L20)
+[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/consoleUtils.mts#L20)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L29)
+[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/consoleUtils.mts#L29)
 
 ***
 
@@ -73,7 +73,7 @@ A localized text label showing elapsed time with units.
 
 #### Source
 
-[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L78)
+[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/consoleUtils.mts#L78)
 
 ***
 
@@ -97,7 +97,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L38)
+[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/consoleUtils.mts#L38)
 
 ***
 
@@ -119,7 +119,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L91)
+[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/consoleUtils.mts#L91)
 
 ***
 
@@ -141,7 +141,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L99)
+[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/consoleUtils.mts#L99)
 
 ***
 
@@ -163,7 +163,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L107)
+[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/consoleUtils.mts#L107)
 
 ***
 
@@ -185,7 +185,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L115)
+[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/consoleUtils.mts#L115)
 
 ***
 
@@ -209,7 +209,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L47)
+[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/consoleUtils.mts#L47)
 
 ***
 
@@ -233,7 +233,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L56)
+[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/consoleUtils.mts#L56)
 
 ***
 
@@ -257,4 +257,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L65)
+[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/consoleUtils.mts#L65)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/consoleUtils.mts#L20)
+[consoleUtils.mts:20](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L20)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/consoleUtils.mts#L29)
+[consoleUtils.mts:29](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L29)
 
 ***
 
@@ -73,7 +73,7 @@ A localized text label showing elapsed time with units.
 
 #### Source
 
-[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/consoleUtils.mts#L78)
+[consoleUtils.mts:78](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L78)
 
 ***
 
@@ -97,7 +97,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/consoleUtils.mts#L38)
+[consoleUtils.mts:38](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L38)
 
 ***
 
@@ -119,7 +119,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/consoleUtils.mts#L91)
+[consoleUtils.mts:91](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L91)
 
 ***
 
@@ -141,7 +141,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/consoleUtils.mts#L99)
+[consoleUtils.mts:99](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L99)
 
 ***
 
@@ -163,7 +163,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/consoleUtils.mts#L107)
+[consoleUtils.mts:107](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L107)
 
 ***
 
@@ -185,7 +185,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/consoleUtils.mts#L115)
+[consoleUtils.mts:115](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L115)
 
 ***
 
@@ -209,7 +209,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/consoleUtils.mts#L47)
+[consoleUtils.mts:47](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L47)
 
 ***
 
@@ -233,7 +233,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/consoleUtils.mts#L56)
+[consoleUtils.mts:56](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L56)
 
 ***
 
@@ -257,4 +257,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/consoleUtils.mts#L65)
+[consoleUtils.mts:65](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/consoleUtils.mts#L65)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -23,7 +23,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/filesystemUtils.mts#L18)
+[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/filesystemUtils.mts#L18)
 
 ***
 
@@ -48,7 +48,7 @@ A localized string representing a file size.
 
 #### Source
 
-[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/filesystemUtils.mts#L60)
+[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/filesystemUtils.mts#L60)
 
 ***
 
@@ -74,7 +74,7 @@ A list of paths.
 
 #### Source
 
-[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/filesystemUtils.mts#L36)
+[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/filesystemUtils.mts#L36)
 
 ***
 
@@ -98,4 +98,4 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/filesystemUtils.mts#L81)
+[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/filesystemUtils.mts#L81)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -23,7 +23,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/filesystemUtils.mts#L18)
+[filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/filesystemUtils.mts#L18)
 
 ***
 
@@ -48,7 +48,7 @@ A localized string representing a file size.
 
 #### Source
 
-[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/filesystemUtils.mts#L60)
+[filesystemUtils.mts:60](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/filesystemUtils.mts#L60)
 
 ***
 
@@ -74,7 +74,7 @@ A list of paths.
 
 #### Source
 
-[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/filesystemUtils.mts#L36)
+[filesystemUtils.mts:36](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/filesystemUtils.mts#L36)
 
 ***
 
@@ -98,4 +98,4 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/filesystemUtils.mts#L81)
+[filesystemUtils.mts:81](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/filesystemUtils.mts#L81)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -38,4 +38,4 @@ Optionally specify a configuration object to customize functionality as follows:
 
 #### Source
 
-[networkUtils.mts:99](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/networkUtils.mts#L99)
+[networkUtils.mts:99](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/networkUtils.mts#L99)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -38,4 +38,4 @@ Optionally specify a configuration object to customize functionality as follows:
 
 #### Source
 
-[networkUtils.mts:99](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/networkUtils.mts#L99)
+[networkUtils.mts:99](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/networkUtils.mts#L99)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -5,7 +5,9 @@
 ### Router
 
 Simple router that handles both eager- and lazy-loaded route handlers to keep your bundle sizes
-small. Both default and named module exports are supported with a concise syntax.
+small. Both default and named module exports are supported with a concise syntax. Appends
+`Server-Timing` values for route loading duration to the request headers; can be disabled via the
+constructor.
 
 Path matches follow glob rules by using `Bun.Glob`. See the
 [documentation for `Bun.Glob`](https://bun.sh/docs/api/glob) for details.
@@ -25,11 +27,18 @@ router
 
 #### Constructors
 
-##### new Router()
+##### new Router(startTime, usesServerTiming)
 
-> **new Router**(): [`Router`](routerUtils.md#router)
+> **new Router**(`startTime`?, `usesServerTiming`?): [`Router`](routerUtils.md#router)
 
 Constructor that creates an empty array for route definitions.
+
+###### Parameters
+
+| Parameter | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `startTime`? | `number` | `undefined` | The start time of loading a route; used to compute `Server-Timing` duration. |
+| `usesServerTiming`? | `boolean` | `true` | Boolean indicating if `Server-Timing` headers are sent or not. |
 
 ###### Returns
 
@@ -37,13 +46,15 @@ Constructor that creates an empty array for route definitions.
 
 ###### Source
 
-[routerUtils.mts:54](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/routerUtils.mts#L54)
+[routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L61)
 
 #### Properties
 
 | Property | Modifier | Type |
 | :------ | :------ | :------ |
 | `#routes` | `private` | `Routes` |
+| `#startTime` | `private` | `number` |
+| `#usesServerTiming` | `private` | `boolean` |
 
 #### Methods
 
@@ -69,7 +80,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:119](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/routerUtils.mts#L119)
+[routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L138)
 
 ##### all()
 
@@ -92,7 +103,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:133](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/routerUtils.mts#L133)
+[routerUtils.mts:152](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L152)
 
 ##### delete()
 
@@ -115,7 +126,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:143](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/routerUtils.mts#L143)
+[routerUtils.mts:162](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L162)
 
 ##### get()
 
@@ -138,7 +149,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:153](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/routerUtils.mts#L153)
+[routerUtils.mts:172](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L172)
 
 ##### handleRequest()
 
@@ -160,7 +171,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Source
 
-[routerUtils.mts:79](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/routerUtils.mts#L79)
+[routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L92)
 
 ##### head()
 
@@ -183,7 +194,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:163](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/routerUtils.mts#L163)
+[routerUtils.mts:182](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L182)
 
 ##### options()
 
@@ -206,7 +217,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:173](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/routerUtils.mts#L173)
+[routerUtils.mts:192](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L192)
 
 ##### patch()
 
@@ -229,7 +240,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:183](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/routerUtils.mts#L183)
+[routerUtils.mts:202](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L202)
 
 ##### post()
 
@@ -252,7 +263,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:193](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/routerUtils.mts#L193)
+[routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L212)
 
 ##### put()
 
@@ -275,4 +286,4 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:203](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/routerUtils.mts#L203)
+[routerUtils.mts:222](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L222)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -46,7 +46,7 @@ Constructor that creates an empty array for route definitions.
 
 ###### Source
 
-[routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L61)
+[routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/routerUtils.mts#L61)
 
 #### Properties
 
@@ -80,7 +80,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L138)
+[routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/routerUtils.mts#L138)
 
 ##### all()
 
@@ -103,7 +103,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:152](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L152)
+[routerUtils.mts:152](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/routerUtils.mts#L152)
 
 ##### delete()
 
@@ -126,7 +126,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:162](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L162)
+[routerUtils.mts:162](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/routerUtils.mts#L162)
 
 ##### get()
 
@@ -149,7 +149,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:172](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L172)
+[routerUtils.mts:172](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/routerUtils.mts#L172)
 
 ##### handleRequest()
 
@@ -171,7 +171,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Source
 
-[routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L92)
+[routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/routerUtils.mts#L92)
 
 ##### head()
 
@@ -194,7 +194,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:182](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L182)
+[routerUtils.mts:182](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/routerUtils.mts#L182)
 
 ##### options()
 
@@ -217,7 +217,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:192](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L192)
+[routerUtils.mts:192](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/routerUtils.mts#L192)
 
 ##### patch()
 
@@ -240,7 +240,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:202](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L202)
+[routerUtils.mts:202](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/routerUtils.mts#L202)
 
 ##### post()
 
@@ -263,7 +263,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L212)
+[routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/routerUtils.mts#L212)
 
 ##### put()
 
@@ -286,4 +286,4 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[routerUtils.mts:222](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/routerUtils.mts#L222)
+[routerUtils.mts:222](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/routerUtils.mts#L222)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -2,6 +2,40 @@
 
 ## Functions
 
+### buildServerTimingHeader()
+
+> **buildServerTimingHeader**(`name`, `startTime`?, `description`?): readonly [`"Server-Timing"`, `string`]
+
+Build a `Server-Timing` header to measure a performance metric using the provided values.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the performance metric. |
+| `startTime`? | `number` | The recorded start time used to compute the metric duration; computed by<br />                   subtracting the time at which this function is called by the start time.<br />                   [Milliseconds is the unit recommended by the W3C](https://w3c.github.io/server-timing/#duration-attribute). |
+| `description`? | `string` | A description of the metric. |
+
+#### Returns
+
+readonly [`"Server-Timing"`, `string`]
+
+A `Server-Timing` header tuple: [`'Server-Timing'`, `string`].
+
+#### Example
+
+```ts
+const startTime = performance.now();
+// ...sometime later...
+request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measures everything'));
+```
+
+#### Source
+
+[timeUtils.mts:30](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/timeUtils.mts#L30)
+
+***
+
 ### getElapsedTimeFormatted()
 
 > **getElapsedTimeFormatted**(`startTime`, `unitsOverride`, `localeOverride`?): `string`
@@ -25,4 +59,4 @@ A localized string showing elapsed time with units.
 
 #### Source
 
-[timeUtils.mts:24](https://github.com/mangs/bun-utils/blob/b4fd429dde11e41571a12d8fccdcd88d164fe6a4/utils/timeUtils.mts#L24)
+[timeUtils.mts:45](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/timeUtils.mts#L45)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -32,7 +32,7 @@ request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measu
 
 #### Source
 
-[timeUtils.mts:30](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/timeUtils.mts#L30)
+[timeUtils.mts:30](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/timeUtils.mts#L30)
 
 ***
 
@@ -59,4 +59,4 @@ A localized string showing elapsed time with units.
 
 #### Source
 
-[timeUtils.mts:45](https://github.com/mangs/bun-utils/blob/914bdf370b21828ea6e678ec7a3f4026805ed144/utils/timeUtils.mts#L45)
+[timeUtils.mts:45](https://github.com/mangs/bun-utils/blob/57b1af54a5b815284a5bd6160168c26a84bfd183/utils/timeUtils.mts#L45)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/utils/timeUtils.mts
+++ b/utils/timeUtils.mts
@@ -13,6 +13,27 @@ type TimeUnits = (typeof timeUnits)[number];
 
 // Local Functions
 /**
+ * Build a `Server-Timing` header to measure a performance metric using the provided values.
+ * @param name        The name of the performance metric.
+ * @param startTime   The recorded start time used to compute the metric duration; computed by
+ *                    subtracting the time at which this function is called by the start time.
+ *                    [Milliseconds is the unit recommended by the W3C](https://w3c.github.io/server-timing/#duration-attribute).
+ * @param description A description of the metric.
+ * @returns           A `Server-Timing` header tuple: [`'Server-Timing'`, `string`].
+ * @example
+ * ```ts
+ * const startTime = performance.now();
+ * // ...sometime later...
+ * request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measures everything'));
+ * ```
+ */
+function buildServerTimingHeader(name: string, startTime?: number, description?: string) {
+  const durationFormatted = startTime ? `;dur=${(performance.now() - startTime).toFixed(2)}` : '';
+  const descriptionFormatted = description ? `;desc="${description}"` : '';
+  return [`Server-Timing`, `${name}${durationFormatted}${descriptionFormatted}`] as const;
+}
+
+/**
  * Get a formatted string representing the time between the provided start time parameter and the
  * time the function is called. Optionally the time units and formatting locale can be overridden.
  * @param startTime      The start time calculated by Bun.nanoseconds().
@@ -55,4 +76,4 @@ function getElapsedTimeFormatted(
 }
 
 // Module Exports
-export { getElapsedTimeFormatted };
+export { buildServerTimingHeader, getElapsedTimeFormatted };


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)
- [x] (OPTIONAL) Build updated documentation using `package.json` script `build:documentation`

**Changes Included**

- Version bump to `2.7.0`
- The `Router` now appends `Server-Timing` values for route loading duration to the request object's headers
- Added new function `buildServerTimingHeader()` to create `Server-Timing` header values
- Added new parameters to the `Router` constructor (in `utils/routerUtils.mts`)
  - `startTime` is the start time of loading a route; used to compute `Server-Timing` duration.
  - `usesServerTiming` is a boolean indicating if `Server-Timing` headers are sent or not