### PR TITLE
Allow `0` to be passed in as `startTime` in `buildServerTimingHeader()` (in `src/timeUtils.mts`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.3
+
+- Allow `0` to be passed in as `startTime` in `buildServerTimingHeader()` (in `src/timeUtils.mts`)
+
 ## 2.8.2
 
 - Add more detailed documentation to the `Router` class in `src/routerUtils.mts`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/src/timeUtils.mts
+++ b/src/timeUtils.mts
@@ -26,7 +26,8 @@ type TimeUnits = (typeof timeUnits)[number];
  * ```
  */
 function buildServerTimingHeader(name: string, startTime?: number, description?: string) {
-  const durationFormatted = startTime ? `;dur=${(performance.now() - startTime).toFixed(2)}` : '';
+  const durationFormatted =
+    typeof startTime === 'number' ? `;dur=${(performance.now() - startTime).toFixed(2)}` : '';
   const descriptionFormatted = description ? `;desc="${description}"` : '';
   return [`Server-Timing`, `${name}${durationFormatted}${descriptionFormatted}`] as const;
 }


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)
- [ ] (OPTIONAL) Build updated documentation using `package.json` script `build:documentation`

**Changes Included**

- Version bump to `2.8.3`
- Allow `0` to be passed in as `startTime` in `buildServerTimingHeader()` (in `src/timeUtils.mts`)