### PR TITLE
Widen the count column so there are 2 space characters minimum between its visible characters and the filename column for `printBuildMetadata()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.15.3
+
+- Widen the count column so there are 2 space characters minimum between its visible characters and the filename column for `printBuildMetadata()`
+  - Improves visibility for outputs where dimmed text isn't possible such as GitHub Actions
+
 ## 2.15.2
 
 - Change alignment of category column from using raw tab characters to computing proper max column width

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/src/buildUtils.mts
+++ b/src/buildUtils.mts
@@ -109,14 +109,14 @@ function printBuildMetadata(buildOutput: BuildOutput, buildOutputDirectory: stri
 
   let fileCount = 0;
   const labelLength = buildArtifactsSorted.length.toString().length;
-  const gutterWidth = labelLength + 2;
+  const gutterWidth = labelLength + 3;
   for (const { kind, pathRelative, size } of buildArtifactsSorted) {
     fileCount += 1;
     const countColumn = dim(`${fileCount.toString().padStart(labelLength, ' ')})`);
     const filenameColumn = pathRelative.padEnd(maxFilenameLength, ' ');
     const sizeColumn = yellow(getHumanReadableFilesize(size).padEnd(maxFileSizeLength, ' '));
     const categoryColumn = dim(`[${kind.slice(0, 1).toUpperCase()}]`);
-    console.log(`${countColumn} ${filenameColumn}  ${sizeColumn}  ${categoryColumn}`);
+    console.log(`${countColumn}  ${filenameColumn}  ${sizeColumn}  ${categoryColumn}`);
   }
   console.log(); // Add spacing between file metadata and size total rows
 


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)
- [ ] (OPTIONAL) Build updated documentation using `package.json` script `build:documentation`

**Changes Included**

- Version bump to `2.15.3`
- Widen the count column so there are 2 space characters minimum between its visible characters and the filename column for `printBuildMetadata()`
  - Improves visibility for outputs where dimmed text isn't possible such as GitHub Actions