### PR TITLE
Add message to build output specifying which environment is being targetted according to environment variable `NODE_ENV`; defaults to `"development"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.15.4
+
+- Add message to build output specifying which environment is being targetted according to environment variable `NODE_ENV`; defaults to `"development"`
+
 ## 2.15.3
 
 - Widen the count column so there are 2 space characters minimum between its visible characters and the filename column for `printBuildMetadata()`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.15.3",
+  "version": "2.15.4",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/src/buildUtils.mts
+++ b/src/buildUtils.mts
@@ -47,7 +47,8 @@ interface BuildConfiguration extends BuildConfig {
  */
 async function buildAndShowMetadata(buildConfiguration: BuildConfiguration) {
   const startTime = nanoseconds();
-  printInfo('Building application artifacts...\n');
+  const buildEnvironment = process.env.NODE_ENV ?? 'development';
+  printInfo(`Building application artifacts for ${buildEnvironment}...\n`);
   const buildOutput = await build(buildConfiguration);
   const performanceLabel = getPerformanceLabel(startTime);
 


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)
- [ ] (OPTIONAL) Build updated documentation using `package.json` script `build:documentation`

**Changes Included**

- Version bump to `2.15.4`
- Add message to build output specifying which environment is being targetted according to environment variable `NODE_ENV`; defaults to `"development"`