### PR TITLE
Add `muteMetadata` parameter to `buildAndShowMetadata()` to optionally prevent printing build metadata to the console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.16.0
+
+- Add `muteMetadata` parameter to `buildAndShowMetadata()` to optionally prevent printing build metadata to the console
+- Renamed retry option `changeRetryDelay` to `onChangeRetryDelay` to better reflect its meaning
+- Documentation cleanup: removed manual options object descriptions from description sections in favor of documenting types directly
+
 ## 2.15.4
 
 - Add message to build output specifying which environment is being targetted according to environment variable `NODE_ENV`; defaults to `"development"`

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -77,7 +77,7 @@ process.exitCode = await buildAndShowMetadata(buildConfiguration);
 
 #### Source
 
-[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/buildUtils.mts#L49)
+[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/buildUtils.mts#L49)
 
 ***
 
@@ -100,4 +100,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/buildUtils.mts#L77)
+[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/buildUtils.mts#L77)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -77,7 +77,7 @@ process.exitCode = await buildAndShowMetadata(buildConfiguration);
 
 #### Source
 
-[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/buildUtils.mts#L49)
+[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/buildUtils.mts#L49)
 
 ***
 
@@ -100,4 +100,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/buildUtils.mts#L77)
+[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/buildUtils.mts#L77)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -77,7 +77,7 @@ process.exitCode = await buildAndShowMetadata(buildConfiguration);
 
 #### Source
 
-[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/buildUtils.mts#L49)
+[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/buildUtils.mts#L49)
 
 ***
 
@@ -100,4 +100,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/buildUtils.mts#L77)
+[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/buildUtils.mts#L77)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -77,7 +77,7 @@ process.exitCode = await buildAndShowMetadata(buildConfiguration);
 
 #### Source
 
-[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/buildUtils.mts#L49)
+[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/buildUtils.mts#L49)
 
 ***
 
@@ -100,4 +100,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/buildUtils.mts#L77)
+[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/buildUtils.mts#L77)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -77,7 +77,7 @@ process.exitCode = await buildAndShowMetadata(buildConfiguration);
 
 #### Source
 
-[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/buildUtils.mts#L49)
+[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/buildUtils.mts#L49)
 
 ***
 
@@ -100,4 +100,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/buildUtils.mts#L77)
+[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/buildUtils.mts#L77)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -77,7 +77,7 @@ process.exitCode = await buildAndShowMetadata(buildConfiguration);
 
 #### Source
 
-[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/buildUtils.mts#L49)
+[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/buildUtils.mts#L49)
 
 ***
 
@@ -100,4 +100,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/buildUtils.mts#L77)
+[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/buildUtils.mts#L77)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -77,7 +77,7 @@ process.exitCode = await buildAndShowMetadata(buildConfiguration);
 
 #### Source
 
-[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/buildUtils.mts#L49)
+[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/buildUtils.mts#L49)
 
 ***
 
@@ -100,4 +100,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/buildUtils.mts#L77)
+[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/buildUtils.mts#L77)

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -44,15 +44,16 @@
 
 ### buildAndShowMetadata()
 
-> **buildAndShowMetadata**(`buildConfiguration`): `Promise`\<`0` \| `1`\>
+> **buildAndShowMetadata**(`buildConfiguration`, `muteMetadata`): `Promise`\<`0` \| `1`\>
 
-Build code using `Bun.build` and a provided build configuration object.
+Build code using `Bun.build()` and a provided build configuration object.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| :------ | :------ | :------ |
-| `buildConfiguration` | [`BuildConfiguration`](buildUtils.md#buildconfiguration) | Configuration object used to build the code. |
+| Parameter | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `buildConfiguration` | [`BuildConfiguration`](buildUtils.md#buildconfiguration) | `undefined` | Configuration object used to build the code. |
+| `muteMetadata` | `boolean` | `false` | Boolean determining whether or not to print build metadata to the console. |
 
 #### Returns
 
@@ -76,7 +77,7 @@ process.exitCode = await buildAndShowMetadata(buildConfiguration);
 
 #### Source
 
-[src/buildUtils.mts:48](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/buildUtils.mts#L48)
+[src/buildUtils.mts:49](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/buildUtils.mts#L49)
 
 ***
 
@@ -90,7 +91,7 @@ Format and print to the command line the provided build metadata.
 
 | Parameter | Type | Description |
 | :------ | :------ | :------ |
-| `buildOutput` | [`BuildOutput`](buildUtils.md#buildoutput) | The return value of `Bun.build()`. |
+| `buildOutput` | [`BuildOutput`](buildUtils.md#buildoutput) | The return value of [`Bun.build()`](https://bun.sh/docs/bundler). |
 | `buildOutputDirectory` | `string` | The output directory when building. |
 
 #### Returns
@@ -99,4 +100,4 @@ Format and print to the command line the provided build metadata.
 
 #### Source
 
-[src/buildUtils.mts:73](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/buildUtils.mts#L73)
+[src/buildUtils.mts:77](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/buildUtils.mts#L77)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L17)
+[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L17)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L26)
+[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L26)
 
 ***
 
@@ -72,7 +72,7 @@ Localized text label showing elapsed time with units.
 
 #### Source
 
-[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L73)
+[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L73)
 
 ***
 
@@ -96,7 +96,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L35)
+[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L35)
 
 ***
 
@@ -118,7 +118,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L82)
+[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L82)
 
 ***
 
@@ -140,7 +140,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L90)
+[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L90)
 
 ***
 
@@ -162,7 +162,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L98)
+[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L98)
 
 ***
 
@@ -184,7 +184,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L106)
+[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L106)
 
 ***
 
@@ -208,7 +208,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L44)
+[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L44)
 
 ***
 
@@ -232,7 +232,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L53)
+[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L53)
 
 ***
 
@@ -256,4 +256,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L62)
+[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L62)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/consoleUtils.mts#L17)
+[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L17)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/consoleUtils.mts#L26)
+[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L26)
 
 ***
 
@@ -72,7 +72,7 @@ Localized text label showing elapsed time with units.
 
 #### Source
 
-[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/consoleUtils.mts#L73)
+[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L73)
 
 ***
 
@@ -96,7 +96,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/consoleUtils.mts#L35)
+[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L35)
 
 ***
 
@@ -118,7 +118,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/consoleUtils.mts#L82)
+[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L82)
 
 ***
 
@@ -140,7 +140,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/consoleUtils.mts#L90)
+[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L90)
 
 ***
 
@@ -162,7 +162,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/consoleUtils.mts#L98)
+[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L98)
 
 ***
 
@@ -184,7 +184,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/consoleUtils.mts#L106)
+[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L106)
 
 ***
 
@@ -208,7 +208,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/consoleUtils.mts#L44)
+[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L44)
 
 ***
 
@@ -232,7 +232,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/consoleUtils.mts#L53)
+[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L53)
 
 ***
 
@@ -256,4 +256,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/consoleUtils.mts#L62)
+[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/consoleUtils.mts#L62)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L17)
+[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L17)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L26)
+[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L26)
 
 ***
 
@@ -72,7 +72,7 @@ Localized text label showing elapsed time with units.
 
 #### Source
 
-[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L73)
+[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L73)
 
 ***
 
@@ -96,7 +96,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L35)
+[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L35)
 
 ***
 
@@ -118,7 +118,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L82)
+[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L82)
 
 ***
 
@@ -140,7 +140,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L90)
+[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L90)
 
 ***
 
@@ -162,7 +162,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L98)
+[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L98)
 
 ***
 
@@ -184,7 +184,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L106)
+[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L106)
 
 ***
 
@@ -208,7 +208,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L44)
+[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L44)
 
 ***
 
@@ -232,7 +232,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L53)
+[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L53)
 
 ***
 
@@ -256,4 +256,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/consoleUtils.mts#L62)
+[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L62)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L17)
+[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L17)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L26)
+[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L26)
 
 ***
 
@@ -72,7 +72,7 @@ Localized text label showing elapsed time with units.
 
 #### Source
 
-[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L73)
+[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L73)
 
 ***
 
@@ -96,7 +96,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L35)
+[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L35)
 
 ***
 
@@ -118,7 +118,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L82)
+[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L82)
 
 ***
 
@@ -140,7 +140,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L90)
+[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L90)
 
 ***
 
@@ -162,7 +162,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L98)
+[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L98)
 
 ***
 
@@ -184,7 +184,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L106)
+[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L106)
 
 ***
 
@@ -208,7 +208,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L44)
+[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L44)
 
 ***
 
@@ -232,7 +232,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L53)
+[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L53)
 
 ***
 
@@ -256,4 +256,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L62)
+[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L62)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L17)
+[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L17)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L26)
+[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L26)
 
 ***
 
@@ -72,7 +72,7 @@ Localized text label showing elapsed time with units.
 
 #### Source
 
-[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L73)
+[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L73)
 
 ***
 
@@ -96,7 +96,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L35)
+[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L35)
 
 ***
 
@@ -118,7 +118,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L82)
+[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L82)
 
 ***
 
@@ -140,7 +140,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L90)
+[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L90)
 
 ***
 
@@ -162,7 +162,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L98)
+[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L98)
 
 ***
 
@@ -184,7 +184,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L106)
+[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L106)
 
 ***
 
@@ -208,7 +208,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L44)
+[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L44)
 
 ***
 
@@ -232,7 +232,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L53)
+[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L53)
 
 ***
 
@@ -256,4 +256,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L62)
+[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/consoleUtils.mts#L62)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L17)
+[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L17)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L26)
+[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L26)
 
 ***
 
@@ -72,7 +72,7 @@ Localized text label showing elapsed time with units.
 
 #### Source
 
-[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L73)
+[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L73)
 
 ***
 
@@ -96,7 +96,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L35)
+[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L35)
 
 ***
 
@@ -118,7 +118,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L82)
+[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L82)
 
 ***
 
@@ -140,7 +140,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L90)
+[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L90)
 
 ***
 
@@ -162,7 +162,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L98)
+[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L98)
 
 ***
 
@@ -184,7 +184,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L106)
+[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L106)
 
 ***
 
@@ -208,7 +208,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L44)
+[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L44)
 
 ***
 
@@ -232,7 +232,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L53)
+[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L53)
 
 ***
 
@@ -256,4 +256,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L62)
+[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/consoleUtils.mts#L62)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L17)
+[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L17)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L26)
+[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L26)
 
 ***
 
@@ -72,7 +72,7 @@ Localized text label showing elapsed time with units.
 
 #### Source
 
-[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L73)
+[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L73)
 
 ***
 
@@ -96,7 +96,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L35)
+[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L35)
 
 ***
 
@@ -118,7 +118,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L82)
+[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L82)
 
 ***
 
@@ -140,7 +140,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L90)
+[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L90)
 
 ***
 
@@ -162,7 +162,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L98)
+[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L98)
 
 ***
 
@@ -184,7 +184,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L106)
+[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L106)
 
 ***
 
@@ -208,7 +208,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L44)
+[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L44)
 
 ***
 
@@ -232,7 +232,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L53)
+[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L53)
 
 ***
 
@@ -256,4 +256,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/consoleUtils.mts#L62)
+[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/consoleUtils.mts#L62)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Source
 
-[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L17)
+[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/consoleUtils.mts#L17)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Source
 
-[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L26)
+[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/consoleUtils.mts#L26)
 
 ***
 
@@ -72,7 +72,7 @@ Localized text label showing elapsed time with units.
 
 #### Source
 
-[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L73)
+[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/consoleUtils.mts#L73)
 
 ***
 
@@ -96,7 +96,7 @@ Text formatted so it appears green.
 
 #### Source
 
-[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L35)
+[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/consoleUtils.mts#L35)
 
 ***
 
@@ -118,7 +118,7 @@ Print an error message to the console in red.
 
 #### Source
 
-[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L82)
+[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/consoleUtils.mts#L82)
 
 ***
 
@@ -140,7 +140,7 @@ Print an informational message to the console in cyan.
 
 #### Source
 
-[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L90)
+[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/consoleUtils.mts#L90)
 
 ***
 
@@ -162,7 +162,7 @@ Print a success message to the console in green.
 
 #### Source
 
-[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L98)
+[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/consoleUtils.mts#L98)
 
 ***
 
@@ -184,7 +184,7 @@ Print a warning message to the console in yellow.
 
 #### Source
 
-[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L106)
+[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/consoleUtils.mts#L106)
 
 ***
 
@@ -208,7 +208,7 @@ Text formatted so it appears red.
 
 #### Source
 
-[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L44)
+[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/consoleUtils.mts#L44)
 
 ***
 
@@ -232,7 +232,7 @@ Text formatted so it appears white.
 
 #### Source
 
-[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L53)
+[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/consoleUtils.mts#L53)
 
 ***
 
@@ -256,4 +256,4 @@ Text formatted so it appears yellow.
 
 #### Source
 
-[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/consoleUtils.mts#L62)
+[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/consoleUtils.mts#L62)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -35,7 +35,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/filesystemUtils.mts#L28)
+[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/filesystemUtils.mts#L28)
 
 ***
 
@@ -60,7 +60,7 @@ A localized string representing a file size.
 
 #### Source
 
-[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/filesystemUtils.mts#L70)
+[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/filesystemUtils.mts#L70)
 
 ***
 
@@ -86,7 +86,7 @@ A list of paths.
 
 #### Source
 
-[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/filesystemUtils.mts#L46)
+[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/filesystemUtils.mts#L46)
 
 ***
 
@@ -110,7 +110,7 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/filesystemUtils.mts#L91)
+[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/filesystemUtils.mts#L91)
 
 ***
 
@@ -168,4 +168,4 @@ await file.append('holy data, batman\n');
 
 #### Source
 
-[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/filesystemUtils.mts#L130)
+[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/filesystemUtils.mts#L130)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -35,7 +35,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/filesystemUtils.mts#L28)
+[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/filesystemUtils.mts#L28)
 
 ***
 
@@ -60,7 +60,7 @@ A localized string representing a file size.
 
 #### Source
 
-[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/filesystemUtils.mts#L70)
+[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/filesystemUtils.mts#L70)
 
 ***
 
@@ -86,7 +86,7 @@ A list of paths.
 
 #### Source
 
-[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/filesystemUtils.mts#L46)
+[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/filesystemUtils.mts#L46)
 
 ***
 
@@ -110,7 +110,7 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/filesystemUtils.mts#L91)
+[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/filesystemUtils.mts#L91)
 
 ***
 
@@ -168,4 +168,4 @@ await file.append('holy data, batman\n');
 
 #### Source
 
-[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/filesystemUtils.mts#L130)
+[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/filesystemUtils.mts#L130)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -35,7 +35,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/filesystemUtils.mts#L28)
+[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/filesystemUtils.mts#L28)
 
 ***
 
@@ -60,7 +60,7 @@ A localized string representing a file size.
 
 #### Source
 
-[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/filesystemUtils.mts#L70)
+[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/filesystemUtils.mts#L70)
 
 ***
 
@@ -86,7 +86,7 @@ A list of paths.
 
 #### Source
 
-[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/filesystemUtils.mts#L46)
+[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/filesystemUtils.mts#L46)
 
 ***
 
@@ -110,7 +110,7 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/filesystemUtils.mts#L91)
+[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/filesystemUtils.mts#L91)
 
 ***
 
@@ -168,4 +168,4 @@ await file.append('holy data, batman\n');
 
 #### Source
 
-[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/filesystemUtils.mts#L130)
+[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/filesystemUtils.mts#L130)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -35,7 +35,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/filesystemUtils.mts#L28)
+[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/filesystemUtils.mts#L28)
 
 ***
 
@@ -60,7 +60,7 @@ A localized string representing a file size.
 
 #### Source
 
-[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/filesystemUtils.mts#L70)
+[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/filesystemUtils.mts#L70)
 
 ***
 
@@ -86,7 +86,7 @@ A list of paths.
 
 #### Source
 
-[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/filesystemUtils.mts#L46)
+[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/filesystemUtils.mts#L46)
 
 ***
 
@@ -110,7 +110,7 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/filesystemUtils.mts#L91)
+[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/filesystemUtils.mts#L91)
 
 ***
 
@@ -168,4 +168,4 @@ await file.append('holy data, batman\n');
 
 #### Source
 
-[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/filesystemUtils.mts#L130)
+[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/filesystemUtils.mts#L130)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -35,7 +35,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/filesystemUtils.mts#L28)
+[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/filesystemUtils.mts#L28)
 
 ***
 
@@ -60,7 +60,7 @@ A localized string representing a file size.
 
 #### Source
 
-[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/filesystemUtils.mts#L70)
+[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/filesystemUtils.mts#L70)
 
 ***
 
@@ -86,7 +86,7 @@ A list of paths.
 
 #### Source
 
-[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/filesystemUtils.mts#L46)
+[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/filesystemUtils.mts#L46)
 
 ***
 
@@ -110,7 +110,7 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/filesystemUtils.mts#L91)
+[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/filesystemUtils.mts#L91)
 
 ***
 
@@ -168,4 +168,4 @@ await file.append('holy data, batman\n');
 
 #### Source
 
-[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/filesystemUtils.mts#L130)
+[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/filesystemUtils.mts#L130)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -35,7 +35,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/filesystemUtils.mts#L28)
+[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/filesystemUtils.mts#L28)
 
 ***
 
@@ -60,7 +60,7 @@ A localized string representing a file size.
 
 #### Source
 
-[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/filesystemUtils.mts#L70)
+[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/filesystemUtils.mts#L70)
 
 ***
 
@@ -86,7 +86,7 @@ A list of paths.
 
 #### Source
 
-[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/filesystemUtils.mts#L46)
+[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/filesystemUtils.mts#L46)
 
 ***
 
@@ -110,7 +110,7 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/filesystemUtils.mts#L91)
+[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/filesystemUtils.mts#L91)
 
 ***
 
@@ -168,4 +168,4 @@ await file.append('holy data, batman\n');
 
 #### Source
 
-[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/filesystemUtils.mts#L130)
+[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/filesystemUtils.mts#L130)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -35,7 +35,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/filesystemUtils.mts#L28)
+[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/filesystemUtils.mts#L28)
 
 ***
 
@@ -60,7 +60,7 @@ A localized string representing a file size.
 
 #### Source
 
-[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/filesystemUtils.mts#L70)
+[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/filesystemUtils.mts#L70)
 
 ***
 
@@ -86,7 +86,7 @@ A list of paths.
 
 #### Source
 
-[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/filesystemUtils.mts#L46)
+[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/filesystemUtils.mts#L46)
 
 ***
 
@@ -110,7 +110,7 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/filesystemUtils.mts#L91)
+[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/filesystemUtils.mts#L91)
 
 ***
 
@@ -168,4 +168,4 @@ await file.append('holy data, batman\n');
 
 #### Source
 
-[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/filesystemUtils.mts#L130)
+[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/filesystemUtils.mts#L130)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -35,7 +35,7 @@ The list of inaccessible paths, if any.
 
 #### Source
 
-[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/filesystemUtils.mts#L28)
+[src/filesystemUtils.mts:28](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/filesystemUtils.mts#L28)
 
 ***
 
@@ -60,7 +60,7 @@ A localized string representing a file size.
 
 #### Source
 
-[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/filesystemUtils.mts#L70)
+[src/filesystemUtils.mts:70](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/filesystemUtils.mts#L70)
 
 ***
 
@@ -86,7 +86,7 @@ A list of paths.
 
 #### Source
 
-[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/filesystemUtils.mts#L46)
+[src/filesystemUtils.mts:46](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/filesystemUtils.mts#L46)
 
 ***
 
@@ -110,7 +110,7 @@ Boolean indicating whether or not the path is accessible.
 
 #### Source
 
-[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/filesystemUtils.mts#L91)
+[src/filesystemUtils.mts:91](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/filesystemUtils.mts#L91)
 
 ***
 
@@ -168,4 +168,4 @@ await file.append('holy data, batman\n');
 
 #### Source
 
-[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/filesystemUtils.mts#L130)
+[src/filesystemUtils.mts:130](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/filesystemUtils.mts#L130)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -30,7 +30,7 @@
 | :------ | :------ | :------ | :------ |
 | `error?` | (`this`: `Server`, `request`: `ErrorLike`) => `undefined` \| `Response` \| `Promise`\<`Response`\> \| `Promise`\<`undefined`\> | - | `Pick.error` |
 | `hostname?` | `string` | What hostname should the server listen on?**Default**`js<br />"0.0.0.0" // listen on all interfaces<br />`**Example**`js<br />"127.0.0.1" // Only listen locally<br />`**Example**`js<br />"remix.run" // Only listen on remix.run<br />``<br /><br />note: hostname should not include a {@link port} | `Pick.hostname` |
-| `httpsOptions?` | [`HttpsOptions`](networkUtils.md#httpsoptions) | - | - |
+| `httpsOptions?` | [`HttpsOptions`](networkUtils.md#httpsoptions) | Options for customizing HTTPS functionality. | - |
 | `port?` | `string` \| `number` | What port should the server listen on?<br /><br />**Default**<br />`process.env.PORT \|\| "3000"` | `Pick.port` |
 
 ## Type Aliases
@@ -50,7 +50,7 @@
 
 #### Source
 
-[src/networkUtils.mts:18](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/networkUtils.mts#L18)
+[src/networkUtils.mts:18](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/networkUtils.mts#L18)
 
 ## Functions
 
@@ -77,7 +77,7 @@ Data returned by `fetch`.
 
 #### Source
 
-[src/networkUtils.mts:89](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/networkUtils.mts#L89)
+[src/networkUtils.mts:92](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/networkUtils.mts#L92)
 
 ***
 
@@ -106,4 +106,4 @@ functionality.
 
 #### Source
 
-[src/networkUtils.mts:176](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/networkUtils.mts#L176)
+[src/networkUtils.mts:179](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/networkUtils.mts#L179)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -94,7 +94,7 @@ Data returned by `fetch`.
 
 #### Source
 
-[src/networkUtils.mts:92](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/networkUtils.mts#L92)
+[src/networkUtils.mts:92](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/networkUtils.mts#L92)
 
 ***
 
@@ -123,4 +123,4 @@ functionality.
 
 #### Source
 
-[src/networkUtils.mts:179](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/networkUtils.mts#L179)
+[src/networkUtils.mts:179](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/networkUtils.mts#L179)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -6,15 +6,15 @@
 
 #### Properties
 
-| Property | Type |
-| :------ | :------ |
-| `certificateAuthorityPath?` | `string` \| `string`[] |
-| `certificatePath` | `string` \| `string`[] |
-| `diffieHellmanParametersPath?` | `string` |
-| `lowMemoryMode?` | `boolean` |
-| `passphrase?` | `string` |
-| `privateKeyPath` | `string` \| `string`[] |
-| `serverName?` | `string` |
+| Property | Type | Description |
+| :------ | :------ | :------ |
+| `certificateAuthorityPath?` | `string` \| `string`[] | Maps to `Bun.serve()`'s `tls.ca` option but only the path. |
+| `certificatePath` | `string` \| `string`[] | Maps to `Bun.serve()`'s `tls.cert` option but only the path. |
+| `diffieHellmanParametersPath?` | `string` | Maps to `Bun.serve()`'s `tls.dhParamsFile` option. |
+| `lowMemoryMode?` | `boolean` | Maps to `Bun.serve()`'s `tls.lowMemoryMode` option. |
+| `passphrase?` | `string` | Maps to `Bun.serve()`'s `tls.passphrase` option. |
+| `privateKeyPath` | `string` \| `string`[] | Maps to `Bun.serve()`'s `tls.key` option but only the path. |
+| `serverName?` | `string` | Maps to `Bun.serve()`'s `tls.serverName` option. |
 
 ***
 
@@ -50,7 +50,7 @@
 
 #### Source
 
-[src/networkUtils.mts:18](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/networkUtils.mts#L18)
+[src/networkUtils.mts:18](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/networkUtils.mts#L18)
 
 ## Functions
 
@@ -77,7 +77,7 @@ Data returned by `fetch`.
 
 #### Source
 
-[src/networkUtils.mts:68](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/networkUtils.mts#L68)
+[src/networkUtils.mts:89](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/networkUtils.mts#L89)
 
 ***
 
@@ -106,4 +106,4 @@ functionality.
 
 #### Source
 
-[src/networkUtils.mts:155](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/networkUtils.mts#L155)
+[src/networkUtils.mts:176](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/networkUtils.mts#L176)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -94,7 +94,7 @@ Data returned by `fetch`.
 
 #### Source
 
-[src/networkUtils.mts:92](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/networkUtils.mts#L92)
+[src/networkUtils.mts:92](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/networkUtils.mts#L92)
 
 ***
 
@@ -123,4 +123,4 @@ functionality.
 
 #### Source
 
-[src/networkUtils.mts:179](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/networkUtils.mts#L179)
+[src/networkUtils.mts:179](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/networkUtils.mts#L179)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -8,13 +8,13 @@
 
 | Property | Type | Description |
 | :------ | :------ | :------ |
-| `certificateAuthorityPath?` | `string` \| `string`[] | Maps to `Bun.serve()`'s `tls.ca` option but only the path. |
-| `certificatePath` | `string` \| `string`[] | Maps to `Bun.serve()`'s `tls.cert` option but only the path. |
-| `diffieHellmanParametersPath?` | `string` | Maps to `Bun.serve()`'s `tls.dhParamsFile` option. |
-| `lowMemoryMode?` | `boolean` | Maps to `Bun.serve()`'s `tls.lowMemoryMode` option. |
-| `passphrase?` | `string` | Maps to `Bun.serve()`'s `tls.passphrase` option. |
-| `privateKeyPath` | `string` \| `string`[] | Maps to `Bun.serve()`'s `tls.key` option but only the path. |
-| `serverName?` | `string` | Maps to `Bun.serve()`'s `tls.serverName` option. |
+| `certificateAuthorityPath?` | `string` \| `string`[] | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.ca` option but only the path. |
+| `certificatePath` | `string` \| `string`[] | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.cert` option but only the path. |
+| `diffieHellmanParametersPath?` | `string` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.dhParamsFile` option. |
+| `lowMemoryMode?` | `boolean` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.lowMemoryMode` option. |
+| `passphrase?` | `string` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.passphrase` option. |
+| `privateKeyPath` | `string` \| `string`[] | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.key` option but only the path. |
+| `serverName?` | `string` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.serverName` option. |
 
 ***
 
@@ -50,7 +50,7 @@
 
 #### Source
 
-[src/networkUtils.mts:18](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/networkUtils.mts#L18)
+[src/networkUtils.mts:18](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/networkUtils.mts#L18)
 
 ## Functions
 
@@ -77,7 +77,7 @@ Data returned by `fetch`.
 
 #### Source
 
-[src/networkUtils.mts:89](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/networkUtils.mts#L89)
+[src/networkUtils.mts:89](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/networkUtils.mts#L89)
 
 ***
 
@@ -106,4 +106,4 @@ functionality.
 
 #### Source
 
-[src/networkUtils.mts:176](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/networkUtils.mts#L176)
+[src/networkUtils.mts:176](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/networkUtils.mts#L176)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -41,16 +41,16 @@
 
 #### Type declaration
 
-| Member | Type |
-| :------ | :------ |
-| `changeRetryDelay` | (`delay`) => `number` |
-| `retryDelay` | `number` |
-| `retryMax` | `number` |
-| `timeout` | `number` |
+| Member | Type | Description |
+| :------ | :------ | :------ |
+| `onChangeRetryDelay` | (`delay`) => `number` | Function describing how `retryDelay` changes with each retry iteration.<br /><br /> |
+| `retryDelay` | `number` | Delay between retries; `onChangeRetryDelay` affects how it changes between retry iterations. |
+| `retryMax` | `number` | Maximum number of retries before an error is thrown. |
+| `timeout` | `number` | Time until the `fetch` request times out; can alternatively be overridden by passing an `AbortSignal` value to the `options.signal` parameter member. |
 
 #### Source
 
-[src/networkUtils.mts:18](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/networkUtils.mts#L18)
+[src/networkUtils.mts:18](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/networkUtils.mts#L18)
 
 ## Functions
 
@@ -67,7 +67,7 @@ environment variable `DEBUG` to a truthy value logs caught and ignored retry err
 | Parameter | Type | Description |
 | :------ | :------ | :------ |
 | `url` | `string` \| `URL` \| `Request` | URL from which to fetch data. |
-| `options` | [`FetchRetryOptions`](networkUtils.md#fetchretryoptions) | Options object that combines `fetch`'s 2nd parameter with 4 new values:<br />               • `changeRetryDelay`: function describing how `retryDelay` changes with each retry iteration.<br />               • `retryDelay`: delay between retries; `changeRetryDelay` affects how it changes between retry iterations.<br />               • `retryMax`: maximum number of retries before an error is thrown.<br />               • `timeout`: time until the `fetch` request times out; can alternatively be overridden by passing an `AbortSignal` value to the `options.signal` parameter member. |
+| `options` | [`FetchRetryOptions`](networkUtils.md#fetchretryoptions) | Options object that combines `fetch`'s 2nd parameter with custom options. |
 
 #### Returns
 
@@ -77,7 +77,7 @@ Data returned by `fetch`.
 
 #### Source
 
-[src/networkUtils.mts:58](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/networkUtils.mts#L58)
+[src/networkUtils.mts:68](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/networkUtils.mts#L68)
 
 ***
 
@@ -87,25 +87,8 @@ Data returned by `fetch`.
 
 Start a development server with the provided entrypoint function; uses `Bun.serve()` as a web
 server. The exact configuration options used are logged to the console if the `DEBUG` environment
-variable is set to a truthy value.
-
-Optionally specify a configuration object to customize functionality as follows:
-```ts
-{
-  error?: (this: Server, request: ErrorLike) => Response | Promise<Response> | Promise<undefined> | undefined // Maps to Bun.serve()'s error option
-  hostname?: string;                              // Defaults to 0.0.0.0; maps to Bun.serve()'s hostname option
-  httpsOptions?: {
-    certificateAuthorityPath?: string | string[]; // Maps to Bun.serve()'s tls.ca option but only the path
-    certificatePath: string | string[];           // Maps to Bun.serve()'s tls.cert option but only the path
-    diffieHellmanParametersPath?: string;         // Maps to Bun.serve()'s tls.dhParamsFile option
-    lowMemoryMode?: boolean;                      // Maps to Bun.serve()'s tls.lowMemoryMode option
-    passphrase?: string;                          // Maps to Bun.serve()'s tls.passphrase option
-    privateKeyPath: string | string[];            // Maps to Bun.serve()'s tls.key option but only the path
-    serverName?: string;                          // Maps to Bun.serve()'s tls.serverName option
-  };
-  port?: string | number;                         // Defaults to process.env.DEVELOPMENT_SERVER_PORT else 80 for HTTP, 443 for HTTPS; maps to Bun.serve()'s port option
-}
-```
+variable is set to a truthy value. Optionally specify a configuration object to customize
+functionality.
 **NOTE:** multiple server instances can be started simultaneously with unique port values.
 
 #### Parameters
@@ -123,4 +106,4 @@ Optionally specify a configuration object to customize functionality as follows:
 
 #### Source
 
-[src/networkUtils.mts:162](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/networkUtils.mts#L162)
+[src/networkUtils.mts:155](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/networkUtils.mts#L155)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -2,6 +2,42 @@
 
 ## Interfaces
 
+### FetchRetryOptions
+
+#### Extends
+
+- `FetchRequestInit`
+
+#### Properties
+
+| Property | Type | Description | Inherited from |
+| :------ | :------ | :------ | :------ |
+| `body?` | `null` \| `BodyInit` | A BodyInit object or null to set request's body. | `FetchRequestInit.body` |
+| `cache?` | `RequestCache` | A string indicating how the request will interact with the browser's cache to set request's cache. | `FetchRequestInit.cache` |
+| `credentials?` | `RequestCredentials` | A string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL. Sets request's credentials. | `FetchRequestInit.credentials` |
+| `headers?` | `HeadersInit` | A Headers object, an object literal, or an array of two-item arrays to set request's headers. | `FetchRequestInit.headers` |
+| `integrity?` | `string` | A cryptographic hash of the resource to be fetched by request. Sets request's integrity. | `FetchRequestInit.integrity` |
+| `keepalive?` | `boolean` | A boolean to set request's keepalive. | `FetchRequestInit.keepalive` |
+| `method?` | `string` | A string to set request's method. | `FetchRequestInit.method` |
+| `mode?` | `RequestMode` | A string to indicate whether the request will use CORS, or will be restricted to same-origin URLs. Sets request's mode. | `FetchRequestInit.mode` |
+| `onChangeRetryDelay?` | (`delay`: `number`) => `number` | Function describing how `retryDelay` changes with each retry iteration.<br /><br /> | - |
+| `priority?` | `RequestPriority` | - | `FetchRequestInit.priority` |
+| `proxy?` | `string` | Override http_proxy or HTTPS_PROXY<br />This is a custom property that is not part of the Fetch API specification. | `FetchRequestInit.proxy` |
+| `redirect?` | `RequestRedirect` | A string indicating whether request follows redirects, results in an error upon encountering a redirect, or returns the redirect (in an opaque fashion). Sets request's redirect. | `FetchRequestInit.redirect` |
+| `referrer?` | `string` | A string whose value is a same-origin URL, "about:client", or the empty string, to set request's referrer. | `FetchRequestInit.referrer` |
+| `referrerPolicy?` | `ReferrerPolicy` | A referrer policy to set request's referrerPolicy. | `FetchRequestInit.referrerPolicy` |
+| `retryDelay?` | `number` | Delay between retries; `onChangeRetryDelay` affects how it changes between retry iterations. | - |
+| `retryMax?` | `number` | Maximum number of retries before an error is thrown. | - |
+| `signal?` | `null` \| `AbortSignal` | An AbortSignal to set request's signal. | `FetchRequestInit.signal` |
+| `timeout?` | `number` | Time until the `fetch` request times out; can alternatively be overridden by passing an `AbortSignal` value to the `options.signal` parameter member. | - |
+| `tls?` | `object` | Override the default TLS options | `FetchRequestInit.tls` |
+| `tls.checkServerIdentity?` | `any` | - | - |
+| `tls.rejectUnauthorized?` | `boolean` | - | - |
+| `verbose?` | `boolean` | Log the raw HTTP request & response to stdout. This API may be<br />removed in a future version of Bun without notice.<br />This is a custom property that is not part of the Fetch API specification.<br />It exists mostly as a debugging tool | `FetchRequestInit.verbose` |
+| `window?` | `null` | Can only be null. Used to disassociate request from any Window. | `FetchRequestInit.window` |
+
+***
+
 ### HttpsOptions
 
 #### Properties
@@ -33,25 +69,6 @@
 | `httpsOptions?` | [`HttpsOptions`](networkUtils.md#httpsoptions) | Options for customizing HTTPS functionality. | - |
 | `port?` | `string` \| `number` | What port should the server listen on?<br /><br />**Default**<br />`process.env.PORT \|\| "3000"` | `Pick.port` |
 
-## Type Aliases
-
-### FetchRetryOptions
-
-> **FetchRetryOptions**: `FetchRequestInit` & `object`
-
-#### Type declaration
-
-| Member | Type | Description |
-| :------ | :------ | :------ |
-| `onChangeRetryDelay` | (`delay`) => `number` | Function describing how `retryDelay` changes with each retry iteration.<br /><br /> |
-| `retryDelay` | `number` | Delay between retries; `onChangeRetryDelay` affects how it changes between retry iterations. |
-| `retryMax` | `number` | Maximum number of retries before an error is thrown. |
-| `timeout` | `number` | Time until the `fetch` request times out; can alternatively be overridden by passing an `AbortSignal` value to the `options.signal` parameter member. |
-
-#### Source
-
-[src/networkUtils.mts:18](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/networkUtils.mts#L18)
-
 ## Functions
 
 ### fetchWithRetry()
@@ -77,7 +94,7 @@ Data returned by `fetch`.
 
 #### Source
 
-[src/networkUtils.mts:92](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/networkUtils.mts#L92)
+[src/networkUtils.mts:92](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/networkUtils.mts#L92)
 
 ***
 
@@ -106,4 +123,4 @@ functionality.
 
 #### Source
 
-[src/networkUtils.mts:179](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/networkUtils.mts#L179)
+[src/networkUtils.mts:179](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/networkUtils.mts#L179)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -94,7 +94,7 @@ Data returned by `fetch`.
 
 #### Source
 
-[src/networkUtils.mts:92](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/networkUtils.mts#L92)
+[src/networkUtils.mts:92](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/networkUtils.mts#L92)
 
 ***
 
@@ -123,4 +123,4 @@ functionality.
 
 #### Source
 
-[src/networkUtils.mts:179](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/networkUtils.mts#L179)
+[src/networkUtils.mts:179](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/networkUtils.mts#L179)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -46,7 +46,7 @@ Constructor that creates an empty array for route definitions.
 
 ###### Source
 
-[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L61)
+[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L61)
 
 #### Properties
 
@@ -80,7 +80,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L138)
+[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L138)
 
 ##### all()
 
@@ -109,7 +109,7 @@ router.all('/**', () => new Response('', { headers: { allow: 'GET' }, status: 40
 
 ###### Source
 
-[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L156)
+[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L156)
 
 ##### delete()
 
@@ -138,7 +138,7 @@ router.delete('/item', { deleteItemRoute: () => import('./routes/deleteItemRoute
 
 ###### Source
 
-[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L170)
+[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L170)
 
 ##### get()
 
@@ -167,7 +167,7 @@ router.get('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L184)
+[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L184)
 
 ##### handleRequest()
 
@@ -189,7 +189,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Source
 
-[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L92)
+[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L92)
 
 ##### head()
 
@@ -218,7 +218,7 @@ router.head('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L198)
+[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L198)
 
 ##### options()
 
@@ -247,7 +247,7 @@ router.options('/item', { deleteItemRoute: () => import('./routes/deleteItemRout
 
 ###### Source
 
-[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L212)
+[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L212)
 
 ##### patch()
 
@@ -276,7 +276,7 @@ router.patch('/item', { patchItemRoute: () => import('./routes/patchItemRoute.mt
 
 ###### Source
 
-[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L226)
+[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L226)
 
 ##### post()
 
@@ -305,7 +305,7 @@ router.post('/item', { postItemRoute: () => import('./routes/postItemRoute.mts')
 
 ###### Source
 
-[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L240)
+[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L240)
 
 ##### put()
 
@@ -334,7 +334,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L254)
+[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L254)
 
 ## Type Aliases
 
@@ -344,7 +344,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L12)
+[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L12)
 
 ***
 
@@ -354,7 +354,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L16)
+[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L16)
 
 ***
 
@@ -364,7 +364,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L15)
+[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L15)
 
 ***
 
@@ -384,7 +384,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L13)
+[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L13)
 
 ***
 
@@ -394,7 +394,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L14)
+[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L14)
 
 ***
 
@@ -404,7 +404,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L17)
+[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L17)
 
 ## Variables
 
@@ -414,4 +414,4 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L20)
+[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L20)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -46,7 +46,7 @@ Constructor that creates an empty array for route definitions.
 
 ###### Source
 
-[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L61)
+[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L61)
 
 #### Properties
 
@@ -80,7 +80,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L138)
+[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L138)
 
 ##### all()
 
@@ -109,7 +109,7 @@ router.all('/**', () => new Response('', { headers: { allow: 'GET' }, status: 40
 
 ###### Source
 
-[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L156)
+[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L156)
 
 ##### delete()
 
@@ -138,7 +138,7 @@ router.delete('/item', { deleteItemRoute: () => import('./routes/deleteItemRoute
 
 ###### Source
 
-[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L170)
+[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L170)
 
 ##### get()
 
@@ -167,7 +167,7 @@ router.get('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L184)
+[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L184)
 
 ##### handleRequest()
 
@@ -189,7 +189,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Source
 
-[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L92)
+[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L92)
 
 ##### head()
 
@@ -218,7 +218,7 @@ router.head('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L198)
+[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L198)
 
 ##### options()
 
@@ -247,7 +247,7 @@ router.options('/item', { deleteItemRoute: () => import('./routes/deleteItemRout
 
 ###### Source
 
-[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L212)
+[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L212)
 
 ##### patch()
 
@@ -276,7 +276,7 @@ router.patch('/item', { patchItemRoute: () => import('./routes/patchItemRoute.mt
 
 ###### Source
 
-[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L226)
+[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L226)
 
 ##### post()
 
@@ -305,7 +305,7 @@ router.post('/item', { postItemRoute: () => import('./routes/postItemRoute.mts')
 
 ###### Source
 
-[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L240)
+[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L240)
 
 ##### put()
 
@@ -334,7 +334,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L254)
+[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L254)
 
 ## Type Aliases
 
@@ -344,7 +344,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L12)
+[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L12)
 
 ***
 
@@ -354,7 +354,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L16)
+[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L16)
 
 ***
 
@@ -364,7 +364,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L15)
+[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L15)
 
 ***
 
@@ -384,7 +384,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L13)
+[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L13)
 
 ***
 
@@ -394,7 +394,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L14)
+[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L14)
 
 ***
 
@@ -404,7 +404,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L17)
+[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L17)
 
 ## Variables
 
@@ -414,4 +414,4 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L20)
+[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L20)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -46,7 +46,7 @@ Constructor that creates an empty array for route definitions.
 
 ###### Source
 
-[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L61)
+[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L61)
 
 #### Properties
 
@@ -80,7 +80,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L138)
+[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L138)
 
 ##### all()
 
@@ -109,7 +109,7 @@ router.all('/**', () => new Response('', { headers: { allow: 'GET' }, status: 40
 
 ###### Source
 
-[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L156)
+[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L156)
 
 ##### delete()
 
@@ -138,7 +138,7 @@ router.delete('/item', { deleteItemRoute: () => import('./routes/deleteItemRoute
 
 ###### Source
 
-[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L170)
+[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L170)
 
 ##### get()
 
@@ -167,7 +167,7 @@ router.get('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L184)
+[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L184)
 
 ##### handleRequest()
 
@@ -189,7 +189,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Source
 
-[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L92)
+[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L92)
 
 ##### head()
 
@@ -218,7 +218,7 @@ router.head('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L198)
+[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L198)
 
 ##### options()
 
@@ -247,7 +247,7 @@ router.options('/item', { deleteItemRoute: () => import('./routes/deleteItemRout
 
 ###### Source
 
-[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L212)
+[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L212)
 
 ##### patch()
 
@@ -276,7 +276,7 @@ router.patch('/item', { patchItemRoute: () => import('./routes/patchItemRoute.mt
 
 ###### Source
 
-[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L226)
+[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L226)
 
 ##### post()
 
@@ -305,7 +305,7 @@ router.post('/item', { postItemRoute: () => import('./routes/postItemRoute.mts')
 
 ###### Source
 
-[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L240)
+[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L240)
 
 ##### put()
 
@@ -334,7 +334,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L254)
+[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L254)
 
 ## Type Aliases
 
@@ -344,7 +344,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L12)
+[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L12)
 
 ***
 
@@ -354,7 +354,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L16)
+[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L16)
 
 ***
 
@@ -364,7 +364,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L15)
+[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L15)
 
 ***
 
@@ -384,7 +384,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L13)
+[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L13)
 
 ***
 
@@ -394,7 +394,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L14)
+[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L14)
 
 ***
 
@@ -404,7 +404,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L17)
+[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L17)
 
 ## Variables
 
@@ -414,4 +414,4 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L20)
+[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/routerUtils.mts#L20)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -46,7 +46,7 @@ Constructor that creates an empty array for route definitions.
 
 ###### Source
 
-[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L61)
+[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L61)
 
 #### Properties
 
@@ -80,7 +80,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L138)
+[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L138)
 
 ##### all()
 
@@ -109,7 +109,7 @@ router.all('/**', () => new Response('', { headers: { allow: 'GET' }, status: 40
 
 ###### Source
 
-[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L156)
+[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L156)
 
 ##### delete()
 
@@ -138,7 +138,7 @@ router.delete('/item', { deleteItemRoute: () => import('./routes/deleteItemRoute
 
 ###### Source
 
-[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L170)
+[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L170)
 
 ##### get()
 
@@ -167,7 +167,7 @@ router.get('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L184)
+[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L184)
 
 ##### handleRequest()
 
@@ -189,7 +189,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Source
 
-[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L92)
+[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L92)
 
 ##### head()
 
@@ -218,7 +218,7 @@ router.head('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L198)
+[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L198)
 
 ##### options()
 
@@ -247,7 +247,7 @@ router.options('/item', { deleteItemRoute: () => import('./routes/deleteItemRout
 
 ###### Source
 
-[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L212)
+[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L212)
 
 ##### patch()
 
@@ -276,7 +276,7 @@ router.patch('/item', { patchItemRoute: () => import('./routes/patchItemRoute.mt
 
 ###### Source
 
-[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L226)
+[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L226)
 
 ##### post()
 
@@ -305,7 +305,7 @@ router.post('/item', { postItemRoute: () => import('./routes/postItemRoute.mts')
 
 ###### Source
 
-[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L240)
+[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L240)
 
 ##### put()
 
@@ -334,7 +334,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L254)
+[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L254)
 
 ## Type Aliases
 
@@ -344,7 +344,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L12)
+[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L12)
 
 ***
 
@@ -354,7 +354,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L16)
+[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L16)
 
 ***
 
@@ -364,7 +364,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L15)
+[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L15)
 
 ***
 
@@ -384,7 +384,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L13)
+[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L13)
 
 ***
 
@@ -394,7 +394,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L14)
+[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L14)
 
 ***
 
@@ -404,7 +404,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L17)
+[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L17)
 
 ## Variables
 
@@ -414,4 +414,4 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L20)
+[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/routerUtils.mts#L20)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -46,7 +46,7 @@ Constructor that creates an empty array for route definitions.
 
 ###### Source
 
-[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L61)
+[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L61)
 
 #### Properties
 
@@ -80,7 +80,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L138)
+[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L138)
 
 ##### all()
 
@@ -109,7 +109,7 @@ router.all('/**', () => new Response('', { headers: { allow: 'GET' }, status: 40
 
 ###### Source
 
-[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L156)
+[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L156)
 
 ##### delete()
 
@@ -138,7 +138,7 @@ router.delete('/item', { deleteItemRoute: () => import('./routes/deleteItemRoute
 
 ###### Source
 
-[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L170)
+[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L170)
 
 ##### get()
 
@@ -167,7 +167,7 @@ router.get('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L184)
+[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L184)
 
 ##### handleRequest()
 
@@ -189,7 +189,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Source
 
-[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L92)
+[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L92)
 
 ##### head()
 
@@ -218,7 +218,7 @@ router.head('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L198)
+[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L198)
 
 ##### options()
 
@@ -247,7 +247,7 @@ router.options('/item', { deleteItemRoute: () => import('./routes/deleteItemRout
 
 ###### Source
 
-[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L212)
+[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L212)
 
 ##### patch()
 
@@ -276,7 +276,7 @@ router.patch('/item', { patchItemRoute: () => import('./routes/patchItemRoute.mt
 
 ###### Source
 
-[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L226)
+[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L226)
 
 ##### post()
 
@@ -305,7 +305,7 @@ router.post('/item', { postItemRoute: () => import('./routes/postItemRoute.mts')
 
 ###### Source
 
-[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L240)
+[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L240)
 
 ##### put()
 
@@ -334,7 +334,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L254)
+[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L254)
 
 ## Type Aliases
 
@@ -344,7 +344,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L12)
+[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L12)
 
 ***
 
@@ -354,7 +354,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L16)
+[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L16)
 
 ***
 
@@ -364,7 +364,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L15)
+[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L15)
 
 ***
 
@@ -384,7 +384,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L13)
+[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L13)
 
 ***
 
@@ -394,7 +394,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L14)
+[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L14)
 
 ***
 
@@ -404,7 +404,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L17)
+[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L17)
 
 ## Variables
 
@@ -414,4 +414,4 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L20)
+[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/routerUtils.mts#L20)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -46,7 +46,7 @@ Constructor that creates an empty array for route definitions.
 
 ###### Source
 
-[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L61)
+[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L61)
 
 #### Properties
 
@@ -80,7 +80,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L138)
+[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L138)
 
 ##### all()
 
@@ -109,7 +109,7 @@ router.all('/**', () => new Response('', { headers: { allow: 'GET' }, status: 40
 
 ###### Source
 
-[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L156)
+[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L156)
 
 ##### delete()
 
@@ -138,7 +138,7 @@ router.delete('/item', { deleteItemRoute: () => import('./routes/deleteItemRoute
 
 ###### Source
 
-[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L170)
+[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L170)
 
 ##### get()
 
@@ -167,7 +167,7 @@ router.get('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L184)
+[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L184)
 
 ##### handleRequest()
 
@@ -189,7 +189,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Source
 
-[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L92)
+[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L92)
 
 ##### head()
 
@@ -218,7 +218,7 @@ router.head('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L198)
+[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L198)
 
 ##### options()
 
@@ -247,7 +247,7 @@ router.options('/item', { deleteItemRoute: () => import('./routes/deleteItemRout
 
 ###### Source
 
-[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L212)
+[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L212)
 
 ##### patch()
 
@@ -276,7 +276,7 @@ router.patch('/item', { patchItemRoute: () => import('./routes/patchItemRoute.mt
 
 ###### Source
 
-[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L226)
+[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L226)
 
 ##### post()
 
@@ -305,7 +305,7 @@ router.post('/item', { postItemRoute: () => import('./routes/postItemRoute.mts')
 
 ###### Source
 
-[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L240)
+[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L240)
 
 ##### put()
 
@@ -334,7 +334,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L254)
+[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L254)
 
 ## Type Aliases
 
@@ -344,7 +344,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L12)
+[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L12)
 
 ***
 
@@ -354,7 +354,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L16)
+[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L16)
 
 ***
 
@@ -364,7 +364,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L15)
+[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L15)
 
 ***
 
@@ -384,7 +384,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L13)
+[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L13)
 
 ***
 
@@ -394,7 +394,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L14)
+[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L14)
 
 ***
 
@@ -404,7 +404,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L17)
+[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L17)
 
 ## Variables
 
@@ -414,4 +414,4 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/routerUtils.mts#L20)
+[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/routerUtils.mts#L20)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -46,7 +46,7 @@ Constructor that creates an empty array for route definitions.
 
 ###### Source
 
-[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L61)
+[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L61)
 
 #### Properties
 
@@ -80,7 +80,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L138)
+[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L138)
 
 ##### all()
 
@@ -109,7 +109,7 @@ router.all('/**', () => new Response('', { headers: { allow: 'GET' }, status: 40
 
 ###### Source
 
-[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L156)
+[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L156)
 
 ##### delete()
 
@@ -138,7 +138,7 @@ router.delete('/item', { deleteItemRoute: () => import('./routes/deleteItemRoute
 
 ###### Source
 
-[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L170)
+[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L170)
 
 ##### get()
 
@@ -167,7 +167,7 @@ router.get('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L184)
+[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L184)
 
 ##### handleRequest()
 
@@ -189,7 +189,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Source
 
-[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L92)
+[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L92)
 
 ##### head()
 
@@ -218,7 +218,7 @@ router.head('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L198)
+[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L198)
 
 ##### options()
 
@@ -247,7 +247,7 @@ router.options('/item', { deleteItemRoute: () => import('./routes/deleteItemRout
 
 ###### Source
 
-[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L212)
+[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L212)
 
 ##### patch()
 
@@ -276,7 +276,7 @@ router.patch('/item', { patchItemRoute: () => import('./routes/patchItemRoute.mt
 
 ###### Source
 
-[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L226)
+[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L226)
 
 ##### post()
 
@@ -305,7 +305,7 @@ router.post('/item', { postItemRoute: () => import('./routes/postItemRoute.mts')
 
 ###### Source
 
-[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L240)
+[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L240)
 
 ##### put()
 
@@ -334,7 +334,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L254)
+[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L254)
 
 ## Type Aliases
 
@@ -344,7 +344,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L12)
+[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L12)
 
 ***
 
@@ -354,7 +354,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L16)
+[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L16)
 
 ***
 
@@ -364,7 +364,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L15)
+[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L15)
 
 ***
 
@@ -384,7 +384,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L13)
+[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L13)
 
 ***
 
@@ -394,7 +394,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L14)
+[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L14)
 
 ***
 
@@ -404,7 +404,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L17)
+[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L17)
 
 ## Variables
 
@@ -414,4 +414,4 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/routerUtils.mts#L20)
+[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/routerUtils.mts#L20)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -46,7 +46,7 @@ Constructor that creates an empty array for route definitions.
 
 ###### Source
 
-[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L61)
+[src/routerUtils.mts:61](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L61)
 
 #### Properties
 
@@ -80,7 +80,7 @@ A reference to the instantiated instance (`this`) so route handler definitions c
 
 ###### Source
 
-[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L138)
+[src/routerUtils.mts:138](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L138)
 
 ##### all()
 
@@ -109,7 +109,7 @@ router.all('/**', () => new Response('', { headers: { allow: 'GET' }, status: 40
 
 ###### Source
 
-[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L156)
+[src/routerUtils.mts:156](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L156)
 
 ##### delete()
 
@@ -138,7 +138,7 @@ router.delete('/item', { deleteItemRoute: () => import('./routes/deleteItemRoute
 
 ###### Source
 
-[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L170)
+[src/routerUtils.mts:170](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L170)
 
 ##### get()
 
@@ -167,7 +167,7 @@ router.get('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L184)
+[src/routerUtils.mts:184](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L184)
 
 ##### handleRequest()
 
@@ -189,7 +189,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Source
 
-[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L92)
+[src/routerUtils.mts:92](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L92)
 
 ##### head()
 
@@ -218,7 +218,7 @@ router.head('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L198)
+[src/routerUtils.mts:198](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L198)
 
 ##### options()
 
@@ -247,7 +247,7 @@ router.options('/item', { deleteItemRoute: () => import('./routes/deleteItemRout
 
 ###### Source
 
-[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L212)
+[src/routerUtils.mts:212](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L212)
 
 ##### patch()
 
@@ -276,7 +276,7 @@ router.patch('/item', { patchItemRoute: () => import('./routes/patchItemRoute.mt
 
 ###### Source
 
-[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L226)
+[src/routerUtils.mts:226](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L226)
 
 ##### post()
 
@@ -305,7 +305,7 @@ router.post('/item', { postItemRoute: () => import('./routes/postItemRoute.mts')
 
 ###### Source
 
-[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L240)
+[src/routerUtils.mts:240](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L240)
 
 ##### put()
 
@@ -334,7 +334,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 ###### Source
 
-[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L254)
+[src/routerUtils.mts:254](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L254)
 
 ## Type Aliases
 
@@ -344,7 +344,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L12)
+[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L12)
 
 ***
 
@@ -354,7 +354,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L16)
+[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L16)
 
 ***
 
@@ -364,7 +364,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L15)
+[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L15)
 
 ***
 
@@ -384,7 +384,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L13)
+[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L13)
 
 ***
 
@@ -394,7 +394,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L14)
+[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L14)
 
 ***
 
@@ -404,7 +404,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L17)
+[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L17)
 
 ## Variables
 
@@ -414,4 +414,4 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Source
 
-[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/routerUtils.mts#L20)
+[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/routerUtils.mts#L20)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -46,7 +46,7 @@ request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measu
 
 #### Source
 
-[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/timeUtils.mts#L35)
+[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/timeUtils.mts#L35)
 
 ***
 
@@ -55,15 +55,7 @@ request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measu
 > **getElapsedTimeFormatted**(`startTime`, `formatOptions`?): `string`
 
 Get a formatted string representing the time between the provided start time parameter and the
-time the function is called. An optional options object can be provided as follows:
-```ts
-{
-  localeOverride?: string;   // Override of the locale used to format and localize the time value.
-  unitsMinimum?: TimeUnits;  // Smallest time unit that can be displayed.
-  unitsOverride?: TimeUnits; // Override of time units to display; supersedes `unitsMinimum`.
-}
-```
-.
+time the function is called. An optional options object can be provided to customize formatting.
 
 #### Parameters
 
@@ -80,7 +72,7 @@ Localized string showing elapsed time with units.
 
 #### Source
 
-[src/timeUtils.mts:57](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/timeUtils.mts#L57)
+[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/timeUtils.mts#L49)
 
 ***
 
@@ -125,7 +117,7 @@ const cmsContent = await measureServerTiming('cmsLoad', request, () =>
 
 #### Source
 
-[src/timeUtils.mts:110](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/timeUtils.mts#L110)
+[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/timeUtils.mts#L102)
 
 ***
 
@@ -149,4 +141,4 @@ Asynchronous sleep function using promises.
 
 #### Source
 
-[src/timeUtils.mts:127](https://github.com/mangs/bun-utils/blob/a932d84f306ef88855ac253a0dcf0fc53b87425a/src/timeUtils.mts#L127)
+[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/timeUtils.mts#L119)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -46,7 +46,7 @@ request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measu
 
 #### Source
 
-[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/timeUtils.mts#L35)
+[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/timeUtils.mts#L35)
 
 ***
 
@@ -72,7 +72,7 @@ Localized string showing elapsed time with units.
 
 #### Source
 
-[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/timeUtils.mts#L49)
+[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/timeUtils.mts#L49)
 
 ***
 
@@ -117,7 +117,7 @@ const cmsContent = await measureServerTiming('cmsLoad', request, () =>
 
 #### Source
 
-[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/timeUtils.mts#L102)
+[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/timeUtils.mts#L102)
 
 ***
 
@@ -141,4 +141,4 @@ Asynchronous sleep function using promises.
 
 #### Source
 
-[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/timeUtils.mts#L119)
+[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/timeUtils.mts#L119)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -46,7 +46,7 @@ request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measu
 
 #### Source
 
-[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/timeUtils.mts#L35)
+[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/timeUtils.mts#L35)
 
 ***
 
@@ -72,7 +72,7 @@ Localized string showing elapsed time with units.
 
 #### Source
 
-[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/timeUtils.mts#L49)
+[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/timeUtils.mts#L49)
 
 ***
 
@@ -117,7 +117,7 @@ const cmsContent = await measureServerTiming('cmsLoad', request, () =>
 
 #### Source
 
-[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/timeUtils.mts#L102)
+[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/timeUtils.mts#L102)
 
 ***
 
@@ -141,4 +141,4 @@ Asynchronous sleep function using promises.
 
 #### Source
 
-[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/timeUtils.mts#L119)
+[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/1160638a144d98845f5264e13c9301037810037e/src/timeUtils.mts#L119)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -46,7 +46,7 @@ request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measu
 
 #### Source
 
-[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/timeUtils.mts#L35)
+[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/timeUtils.mts#L35)
 
 ***
 
@@ -72,7 +72,7 @@ Localized string showing elapsed time with units.
 
 #### Source
 
-[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/timeUtils.mts#L49)
+[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/timeUtils.mts#L49)
 
 ***
 
@@ -117,7 +117,7 @@ const cmsContent = await measureServerTiming('cmsLoad', request, () =>
 
 #### Source
 
-[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/timeUtils.mts#L102)
+[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/timeUtils.mts#L102)
 
 ***
 
@@ -141,4 +141,4 @@ Asynchronous sleep function using promises.
 
 #### Source
 
-[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/timeUtils.mts#L119)
+[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/timeUtils.mts#L119)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -6,11 +6,11 @@
 
 #### Properties
 
-| Property | Type |
-| :------ | :------ |
-| `localeOverride?` | `string` |
-| `unitsMinimum?` | `"ns"` \| `"μs"` \| `"ms"` \| `"s"` |
-| `unitsOverride?` | `"ns"` \| `"μs"` \| `"ms"` \| `"s"` |
+| Property | Type | Description |
+| :------ | :------ | :------ |
+| `localeOverride?` | `string` | Override of the locale used to format and localize the time value. |
+| `unitsMinimum?` | `"ns"` \| `"μs"` \| `"ms"` \| `"s"` | Smallest time unit that can be displayed. |
+| `unitsOverride?` | `"ns"` \| `"μs"` \| `"ms"` \| `"s"` | Override of time units to display; supersedes `unitsMinimum`. |
 
 ## Functions
 
@@ -46,7 +46,7 @@ request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measu
 
 #### Source
 
-[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/timeUtils.mts#L35)
+[src/timeUtils.mts:44](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/timeUtils.mts#L44)
 
 ***
 
@@ -72,7 +72,7 @@ Localized string showing elapsed time with units.
 
 #### Source
 
-[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/timeUtils.mts#L49)
+[src/timeUtils.mts:58](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/timeUtils.mts#L58)
 
 ***
 
@@ -117,7 +117,7 @@ const cmsContent = await measureServerTiming('cmsLoad', request, () =>
 
 #### Source
 
-[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/timeUtils.mts#L102)
+[src/timeUtils.mts:111](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/timeUtils.mts#L111)
 
 ***
 
@@ -141,4 +141,4 @@ Asynchronous sleep function using promises.
 
 #### Source
 
-[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/f8f4535f5d74cc12b4b18b9c87d795c98eddbdf8/src/timeUtils.mts#L119)
+[src/timeUtils.mts:128](https://github.com/mangs/bun-utils/blob/dceacb326e197270cbcb35b6094ebb0e59724f89/src/timeUtils.mts#L128)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -46,7 +46,7 @@ request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measu
 
 #### Source
 
-[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/timeUtils.mts#L35)
+[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/timeUtils.mts#L35)
 
 ***
 
@@ -72,7 +72,7 @@ Localized string showing elapsed time with units.
 
 #### Source
 
-[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/timeUtils.mts#L49)
+[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/timeUtils.mts#L49)
 
 ***
 
@@ -117,7 +117,7 @@ const cmsContent = await measureServerTiming('cmsLoad', request, () =>
 
 #### Source
 
-[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/timeUtils.mts#L102)
+[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/timeUtils.mts#L102)
 
 ***
 
@@ -141,4 +141,4 @@ Asynchronous sleep function using promises.
 
 #### Source
 
-[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/timeUtils.mts#L119)
+[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/8ab5575739fb6c2cf90f32b94496950103773510/src/timeUtils.mts#L119)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -46,7 +46,7 @@ request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measu
 
 #### Source
 
-[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/timeUtils.mts#L35)
+[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/timeUtils.mts#L35)
 
 ***
 
@@ -72,7 +72,7 @@ Localized string showing elapsed time with units.
 
 #### Source
 
-[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/timeUtils.mts#L49)
+[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/timeUtils.mts#L49)
 
 ***
 
@@ -117,7 +117,7 @@ const cmsContent = await measureServerTiming('cmsLoad', request, () =>
 
 #### Source
 
-[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/timeUtils.mts#L102)
+[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/timeUtils.mts#L102)
 
 ***
 
@@ -141,4 +141,4 @@ Asynchronous sleep function using promises.
 
 #### Source
 
-[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/a06a7d84530c4bdd56ac024b1dbf13015586c556/src/timeUtils.mts#L119)
+[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/5b4e3b17a9426120bf6a592afdde1017c640fa88/src/timeUtils.mts#L119)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -46,7 +46,7 @@ request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measu
 
 #### Source
 
-[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/timeUtils.mts#L35)
+[src/timeUtils.mts:35](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/timeUtils.mts#L35)
 
 ***
 
@@ -72,7 +72,7 @@ Localized string showing elapsed time with units.
 
 #### Source
 
-[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/timeUtils.mts#L49)
+[src/timeUtils.mts:49](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/timeUtils.mts#L49)
 
 ***
 
@@ -117,7 +117,7 @@ const cmsContent = await measureServerTiming('cmsLoad', request, () =>
 
 #### Source
 
-[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/timeUtils.mts#L102)
+[src/timeUtils.mts:102](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/timeUtils.mts#L102)
 
 ***
 
@@ -141,4 +141,4 @@ Asynchronous sleep function using promises.
 
 #### Source
 
-[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/a482a2b0dfa0788ec97d1083804c51429ea0a4a3/src/timeUtils.mts#L119)
+[src/timeUtils.mts:119](https://github.com/mangs/bun-utils/blob/3a4cedc1cd242723f771330d70afea04f57de467/src/timeUtils.mts#L119)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.15.4",
+  "version": "2.16.0",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/src/buildUtils.mts
+++ b/src/buildUtils.mts
@@ -29,8 +29,9 @@ interface BuildConfiguration extends BuildConfig {
 
 // Local Functions
 /**
- * Build code using `Bun.build` and a provided build configuration object.
+ * Build code using `Bun.build()` and a provided build configuration object.
  * @param buildConfiguration Configuration object used to build the code.
+ * @param muteMetadata       Boolean determining whether or not to print build metadata to the console.
  * @returns                  Number corresponding to the desired process exit code.
  * @example
  * ```ts
@@ -45,7 +46,7 @@ interface BuildConfiguration extends BuildConfig {
  * process.exitCode = await buildAndShowMetadata(buildConfiguration);
  * ```
  */
-async function buildAndShowMetadata(buildConfiguration: BuildConfiguration) {
+async function buildAndShowMetadata(buildConfiguration: BuildConfiguration, muteMetadata = false) {
   const startTime = nanoseconds();
   const buildEnvironment = process.env.NODE_ENV ?? 'development';
   printInfo(`Building application artifacts for ${buildEnvironment}...\n`);
@@ -60,15 +61,17 @@ async function buildAndShowMetadata(buildConfiguration: BuildConfiguration) {
     return 1;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define -- functions get hoisted
-  printBuildMetadata(buildOutput, buildConfiguration.outdir);
+  if (!muteMetadata) {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define -- functions get hoisted
+    printBuildMetadata(buildOutput, buildConfiguration.outdir);
+  }
   printSuccess(`Build success ${performanceLabel}`);
   return 0;
 }
 
 /**
  * Format and print to the command line the provided build metadata.
- * @param buildOutput          The return value of `Bun.build()`.
+ * @param buildOutput          The return value of [`Bun.build()`](https://bun.sh/docs/bundler).
  * @param buildOutputDirectory The output directory when building.
  */
 function printBuildMetadata(buildOutput: BuildOutput, buildOutputDirectory: string) {

--- a/src/networkUtils.mts
+++ b/src/networkUtils.mts
@@ -38,31 +38,31 @@ type FetchRetryOptions = FetchRequestInit & {
 
 interface HttpsOptions {
   /**
-   * Maps to `Bun.serve()`'s `tls.ca` option but only the path.
+   * Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.ca` option but only the path.
    */
   certificateAuthorityPath?: string | string[];
   /**
-   * Maps to `Bun.serve()`'s `tls.cert` option but only the path.
+   * Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.cert` option but only the path.
    */
   certificatePath: string | string[];
   /**
-   * Maps to `Bun.serve()`'s `tls.dhParamsFile` option.
+   * Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.dhParamsFile` option.
    */
   diffieHellmanParametersPath?: string;
   /**
-   * Maps to `Bun.serve()`'s `tls.lowMemoryMode` option.
+   * Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.lowMemoryMode` option.
    */
   lowMemoryMode?: boolean;
   /**
-   * Maps to `Bun.serve()`'s `tls.passphrase` option.
+   * Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.passphrase` option.
    */
   passphrase?: string;
   /**
-   * Maps to `Bun.serve()`'s `tls.key` option but only the path.
+   * Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.key` option but only the path.
    */
   privateKeyPath: string | string[];
   /**
-   * Maps to `Bun.serve()`'s `tls.serverName` option.
+   * Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.serverName` option.
    */
   serverName?: string;
 }

--- a/src/networkUtils.mts
+++ b/src/networkUtils.mts
@@ -68,6 +68,9 @@ interface HttpsOptions {
 }
 
 interface ServerConfiguration extends Pick<ServeOptions, 'error' | 'hostname' | 'port'> {
+  /**
+   * Options for customizing HTTPS functionality.
+   */
   httpsOptions?: HttpsOptions;
 }
 

--- a/src/networkUtils.mts
+++ b/src/networkUtils.mts
@@ -15,7 +15,7 @@ import type { Serve, ServeOptions, Server } from 'bun';
 
 // Local Types
 // eslint-disable-next-line no-undef -- not sure why FetchRequestInit invisible to ESLint
-type FetchRetryOptions = FetchRequestInit & {
+interface FetchRetryOptions extends FetchRequestInit {
   /**
    * Function describing how `retryDelay` changes with each retry iteration.
    * @param delay Existing delay value.
@@ -34,7 +34,7 @@ type FetchRetryOptions = FetchRequestInit & {
    * Time until the `fetch` request times out; can alternatively be overridden by passing an `AbortSignal` value to the `options.signal` parameter member.
    */
   timeout?: number;
-};
+}
 
 interface HttpsOptions {
   /**

--- a/src/networkUtils.mts
+++ b/src/networkUtils.mts
@@ -37,12 +37,33 @@ type FetchRetryOptions = FetchRequestInit & {
 };
 
 interface HttpsOptions {
+  /**
+   * Maps to `Bun.serve()`'s `tls.ca` option but only the path.
+   */
   certificateAuthorityPath?: string | string[];
+  /**
+   * Maps to `Bun.serve()`'s `tls.cert` option but only the path.
+   */
   certificatePath: string | string[];
+  /**
+   * Maps to `Bun.serve()`'s `tls.dhParamsFile` option.
+   */
   diffieHellmanParametersPath?: string;
+  /**
+   * Maps to `Bun.serve()`'s `tls.lowMemoryMode` option.
+   */
   lowMemoryMode?: boolean;
+  /**
+   * Maps to `Bun.serve()`'s `tls.passphrase` option.
+   */
   passphrase?: string;
+  /**
+   * Maps to `Bun.serve()`'s `tls.key` option but only the path.
+   */
   privateKeyPath: string | string[];
+  /**
+   * Maps to `Bun.serve()`'s `tls.serverName` option.
+   */
   serverName?: string;
 }
 

--- a/src/timeUtils.mts
+++ b/src/timeUtils.mts
@@ -11,8 +11,17 @@ const timeUnits = ['ns', 'μs', 'ms', 's'] as const;
 // Local Types
 type TimeUnits = (typeof timeUnits)[number];
 interface FormatOptions {
+  /**
+   * Override of the locale used to format and localize the time value.
+   */
   localeOverride?: string;
+  /**
+   * Smallest time unit that can be displayed.
+   */
   unitsMinimum?: TimeUnits;
+  /**
+   * Override of time units to display; supersedes `unitsMinimum`.
+   */
   unitsOverride?: TimeUnits;
 }
 

--- a/src/timeUtils.mts
+++ b/src/timeUtils.mts
@@ -41,15 +41,7 @@ function buildServerTimingHeader(name: string, startTime?: number, description?:
 
 /**
  * Get a formatted string representing the time between the provided start time parameter and the
- * time the function is called. An optional options object can be provided as follows:
- * ```ts
- * {
- *   localeOverride?: string;   // Override of the locale used to format and localize the time value.
- *   unitsMinimum?: TimeUnits;  // Smallest time unit that can be displayed.
- *   unitsOverride?: TimeUnits; // Override of time units to display; supersedes `unitsMinimum`.
- * }
- * ```
- * .
+ * time the function is called. An optional options object can be provided to customize formatting.
  * @param startTime     Start time calculated by `Bun.nanoseconds()`.
  * @param formatOptions Options object for formatting customization.
  * @returns             Localized string showing elapsed time with units.
@@ -122,7 +114,7 @@ async function measureServerTiming<T>(
 /**
  * Asynchronous sleep function using promises.
  * @param duration Length of time to sleep.
- * @returns `Promise` that resolves when the specified duration expires.
+ * @returns        `Promise` that resolves when the specified duration expires.
  */
 function sleep(duration: number) {
   return new Promise((resolve) => {


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)
- [x] (OPTIONAL) Build updated documentation using `package.json` script `build:documentation`

**Changes Included**

- Version bump to `2.16.0`
- Add `muteMetadata` parameter to `buildAndShowMetadata()` to optionally prevent printing build metadata to the console
- Renamed retry option `changeRetryDelay` to `onChangeRetryDelay` to better reflect its meaning
- Documentation cleanup: removed manual options object descriptions from description sections in favor of documenting types directly