### PR TITLE
Adjust newline output when `muteMetadata` is passed to `buildAndShowMetadata()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.16.2
+
+- Adjust newline output when `muteMetadata` is passed to `buildAndShowMetadata()`
+
 ## 2.16.1
 
 - Add missing type documentation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/src/buildUtils.mts
+++ b/src/buildUtils.mts
@@ -52,7 +52,7 @@ interface BuildConfiguration extends BuildConfig {
 async function buildAndShowMetadata(buildConfiguration: BuildConfiguration, muteMetadata = false) {
   const startTime = nanoseconds();
   const buildEnvironment = process.env.NODE_ENV ?? 'development';
-  printInfo(`Building application artifacts for ${buildEnvironment}...\n`);
+  printInfo(`Building application artifacts for ${buildEnvironment}...`);
   const buildOutput = await build(buildConfiguration);
   const performanceLabel = getPerformanceLabel(startTime);
 
@@ -65,6 +65,7 @@ async function buildAndShowMetadata(buildConfiguration: BuildConfiguration, mute
   }
 
   if (!muteMetadata) {
+    console.log();
     // eslint-disable-next-line @typescript-eslint/no-use-before-define -- functions get hoisted
     printBuildMetadata(buildOutput, buildConfiguration.outdir);
   }


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)
- [ ] (OPTIONAL) Build updated documentation using `package.json` script `build:documentation`

**Changes Included**

- Version bump to `2.16.2`
- Adjust newline output when `muteMetadata` is passed to `buildAndShowMetadata()`