### PR TITLE
Add additional parameter `usesOneThread` to `measureCpuUsage()` and `measurePerformanceMetrics()` to decide if 1 or all threads are used for percent computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.24.0
+
+- Add additional parameter `usesOneThread` to `measureCpuUsage()` and `measurePerformanceMetrics()` to decide if 1 or all threads are used for percent computation
+
 ## 2.23.1
 
 - Upgrade `oven-sh/setup-bun` action to `v2`

--- a/documentation/buildUtils.md
+++ b/documentation/buildUtils.md
@@ -20,7 +20,7 @@
 | `loader?` | `object` | - | - | `BuildConfig.loader` | node\_modules/bun-types/bun.d.ts:1574 |
 | `minify?` | `boolean` \| `object` | - | - | `BuildConfig.minify` | node\_modules/bun-types/bun.d.ts:1584 |
 | `naming?` | `string` \| `object` | - | - | `BuildConfig.naming` | node\_modules/bun-types/bun.d.ts:1559 |
-| `outdir` | `string` | Output directory. | `BuildConfig.outdir` | - | [src/buildUtils.mts:30](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/buildUtils.mts#L30) |
+| `outdir` | `string` | Output directory. | `BuildConfig.outdir` | - | [src/buildUtils.mts:30](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/buildUtils.mts#L30) |
 | `plugins?` | `BunPlugin`[] | - | - | `BuildConfig.plugins` | node\_modules/bun-types/bun.d.ts:1568 |
 | `publicPath?` | `string` | - | - | `BuildConfig.publicPath` | node\_modules/bun-types/bun.d.ts:1571 |
 | `root?` | `string` | - | - | `BuildConfig.root` | node\_modules/bun-types/bun.d.ts:1566 |
@@ -77,7 +77,7 @@ process.exitCode = await buildAndShowMetadata(buildConfiguration);
 
 #### Defined in
 
-[src/buildUtils.mts:52](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/buildUtils.mts#L52)
+[src/buildUtils.mts:52](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/buildUtils.mts#L52)
 
 ***
 
@@ -100,4 +100,4 @@ Format and print to the command line the provided build metadata.
 
 #### Defined in
 
-[src/buildUtils.mts:81](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/buildUtils.mts#L81)
+[src/buildUtils.mts:81](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/buildUtils.mts#L81)

--- a/documentation/consoleUtils.md
+++ b/documentation/consoleUtils.md
@@ -22,7 +22,7 @@ Text formatted so it appears cyan.
 
 #### Defined in
 
-[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/consoleUtils.mts#L17)
+[src/consoleUtils.mts:17](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/consoleUtils.mts#L17)
 
 ***
 
@@ -46,7 +46,7 @@ Text formatted so it appears dim.
 
 #### Defined in
 
-[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/consoleUtils.mts#L26)
+[src/consoleUtils.mts:26](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/consoleUtils.mts#L26)
 
 ***
 
@@ -72,7 +72,7 @@ Localized text label showing elapsed time with units.
 
 #### Defined in
 
-[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/consoleUtils.mts#L73)
+[src/consoleUtils.mts:73](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/consoleUtils.mts#L73)
 
 ***
 
@@ -96,7 +96,7 @@ Text formatted so it appears green.
 
 #### Defined in
 
-[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/consoleUtils.mts#L35)
+[src/consoleUtils.mts:35](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/consoleUtils.mts#L35)
 
 ***
 
@@ -118,7 +118,7 @@ Print an error message to the console in red.
 
 #### Defined in
 
-[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/consoleUtils.mts#L82)
+[src/consoleUtils.mts:82](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/consoleUtils.mts#L82)
 
 ***
 
@@ -140,7 +140,7 @@ Print an informational message to the console in cyan.
 
 #### Defined in
 
-[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/consoleUtils.mts#L90)
+[src/consoleUtils.mts:90](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/consoleUtils.mts#L90)
 
 ***
 
@@ -162,7 +162,7 @@ Print a success message to the console in green.
 
 #### Defined in
 
-[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/consoleUtils.mts#L98)
+[src/consoleUtils.mts:98](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/consoleUtils.mts#L98)
 
 ***
 
@@ -184,7 +184,7 @@ Print a warning message to the console in yellow.
 
 #### Defined in
 
-[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/consoleUtils.mts#L106)
+[src/consoleUtils.mts:106](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/consoleUtils.mts#L106)
 
 ***
 
@@ -208,7 +208,7 @@ Text formatted so it appears red.
 
 #### Defined in
 
-[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/consoleUtils.mts#L44)
+[src/consoleUtils.mts:44](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/consoleUtils.mts#L44)
 
 ***
 
@@ -232,7 +232,7 @@ Text formatted so it appears white.
 
 #### Defined in
 
-[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/consoleUtils.mts#L53)
+[src/consoleUtils.mts:53](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/consoleUtils.mts#L53)
 
 ***
 
@@ -256,4 +256,4 @@ Text formatted so it appears yellow.
 
 #### Defined in
 
-[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/consoleUtils.mts#L62)
+[src/consoleUtils.mts:62](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/consoleUtils.mts#L62)

--- a/documentation/filesystemUtils.md
+++ b/documentation/filesystemUtils.md
@@ -8,8 +8,8 @@
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `path?` | `string` | Path where the temporary file should be created. | [src/filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/filesystemUtils.mts#L18) |
-| `writerOptions?` | `object` | Options object defined by the first parameter accepted by `BunFile.writer()`. | [src/filesystemUtils.mts:22](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/filesystemUtils.mts#L22) |
+| `path?` | `string` | Path where the temporary file should be created. | [src/filesystemUtils.mts:18](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/filesystemUtils.mts#L18) |
+| `writerOptions?` | `object` | Options object defined by the first parameter accepted by `BunFile.writer()`. | [src/filesystemUtils.mts:22](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/filesystemUtils.mts#L22) |
 | `writerOptions.highWaterMark?` | `number` | - | node\_modules/bun-types/bun.d.ts:1200 |
 
 ## Functions
@@ -35,7 +35,7 @@ The list of inaccessible paths, if any.
 
 #### Defined in
 
-[src/filesystemUtils.mts:34](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/filesystemUtils.mts#L34)
+[src/filesystemUtils.mts:34](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/filesystemUtils.mts#L34)
 
 ***
 
@@ -60,7 +60,7 @@ A localized string representing a file size.
 
 #### Defined in
 
-[src/filesystemUtils.mts:76](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/filesystemUtils.mts#L76)
+[src/filesystemUtils.mts:76](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/filesystemUtils.mts#L76)
 
 ***
 
@@ -86,7 +86,7 @@ A list of paths.
 
 #### Defined in
 
-[src/filesystemUtils.mts:52](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/filesystemUtils.mts#L52)
+[src/filesystemUtils.mts:52](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/filesystemUtils.mts#L52)
 
 ***
 
@@ -110,7 +110,7 @@ Boolean indicating whether or not the path is accessible.
 
 #### Defined in
 
-[src/filesystemUtils.mts:97](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/filesystemUtils.mts#L97)
+[src/filesystemUtils.mts:97](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/filesystemUtils.mts#L97)
 
 ***
 
@@ -146,8 +146,8 @@ Temporary file instance object.
 
 | Name | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `[asyncDispose]` | `Promise`\<`void`\> | Asynchronous automatic disposal function. | [src/filesystemUtils.mts:156](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/filesystemUtils.mts#L156) |
-| `append` | `Promise`\<`void`\> | Append string contents to the target temporary file. | [src/filesystemUtils.mts:146](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/filesystemUtils.mts#L146) |
+| `[asyncDispose]` | `Promise`\<`void`\> | Asynchronous automatic disposal function. | [src/filesystemUtils.mts:156](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/filesystemUtils.mts#L156) |
+| `append` | `Promise`\<`void`\> | Append string contents to the target temporary file. | [src/filesystemUtils.mts:146](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/filesystemUtils.mts#L146) |
 
 #### See
 
@@ -168,4 +168,4 @@ await file.append('holy data, batman\n');
 
 #### Defined in
 
-[src/filesystemUtils.mts:136](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/filesystemUtils.mts#L136)
+[src/filesystemUtils.mts:136](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/filesystemUtils.mts#L136)

--- a/documentation/networkUtils.md
+++ b/documentation/networkUtils.md
@@ -20,17 +20,17 @@
 | `keepalive?` | `boolean` | A boolean to set request's keepalive. | `FetchRequestInit.keepalive` | node\_modules/typescript/lib/lib.dom.d.ts:1703 |
 | `method?` | `string` | A string to set request's method. | `FetchRequestInit.method` | node\_modules/typescript/lib/lib.dom.d.ts:1705 |
 | `mode?` | `RequestMode` | A string to indicate whether the request will use CORS, or will be restricted to same-origin URLs. Sets request's mode. | `FetchRequestInit.mode` | node\_modules/typescript/lib/lib.dom.d.ts:1707 |
-| `onBypassRetry?` | (`statusCode`: `number`) => `boolean` | Function allowing arbitrary status codes to bypass the retry process. **Example** `fetchWithRetry(url, { onBypassRetry: (statusCode) => statusCode === 404 });` | - | [src/networkUtils.mts:34](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L34) |
-| `onChangeRetryDelay?` | (`delay`: `number`) => `number` | Function describing how `retryDelay` changes with each retry iteration. | - | [src/networkUtils.mts:40](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L40) |
+| `onBypassRetry?` | (`statusCode`: `number`) => `boolean` | Function allowing arbitrary status codes to bypass the retry process. **Example** `fetchWithRetry(url, { onBypassRetry: (statusCode) => statusCode === 404 });` | - | [src/networkUtils.mts:34](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L34) |
+| `onChangeRetryDelay?` | (`delay`: `number`) => `number` | Function describing how `retryDelay` changes with each retry iteration. | - | [src/networkUtils.mts:40](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L40) |
 | `priority?` | `RequestPriority` | - | `FetchRequestInit.priority` | node\_modules/typescript/lib/lib.dom.d.ts:1708 |
 | `proxy?` | `string` | Override http_proxy or HTTPS_PROXY This is a custom property that is not part of the Fetch API specification. | `FetchRequestInit.proxy` | node\_modules/bun-types/globals.d.ts:894 |
 | `redirect?` | `RequestRedirect` | A string indicating whether request follows redirects, results in an error upon encountering a redirect, or returns the redirect (in an opaque fashion). Sets request's redirect. | `FetchRequestInit.redirect` | node\_modules/typescript/lib/lib.dom.d.ts:1710 |
 | `referrer?` | `string` | A string whose value is a same-origin URL, "about:client", or the empty string, to set request's referrer. | `FetchRequestInit.referrer` | node\_modules/typescript/lib/lib.dom.d.ts:1712 |
 | `referrerPolicy?` | `ReferrerPolicy` | A referrer policy to set request's referrerPolicy. | `FetchRequestInit.referrerPolicy` | node\_modules/typescript/lib/lib.dom.d.ts:1714 |
-| `retries?` | `number` | Maximum number of retries before an error is thrown. | - | [src/networkUtils.mts:48](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L48) |
-| `retryDelay?` | `number` | Delay between retries; `onChangeRetryDelay` affects how it changes between retry iterations. | - | [src/networkUtils.mts:44](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L44) |
+| `retries?` | `number` | Maximum number of retries before an error is thrown. | - | [src/networkUtils.mts:48](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L48) |
+| `retryDelay?` | `number` | Delay between retries; `onChangeRetryDelay` affects how it changes between retry iterations. | - | [src/networkUtils.mts:44](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L44) |
 | `signal?` | `null` \| `AbortSignal` | An AbortSignal to set request's signal. | `FetchRequestInit.signal` | node\_modules/typescript/lib/lib.dom.d.ts:1716 |
-| `timeout?` | `number` | Time until the `fetch` request times out; can alternatively be overridden by passing an `AbortSignal` value to the `options.signal` parameter member. | - | [src/networkUtils.mts:52](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L52) |
+| `timeout?` | `number` | Time until the `fetch` request times out; can alternatively be overridden by passing an `AbortSignal` value to the `options.signal` parameter member. | - | [src/networkUtils.mts:52](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L52) |
 | `tls?` | `object` | Override the default TLS options | `FetchRequestInit.tls` | node\_modules/bun-types/globals.d.ts:899 |
 | `tls.checkServerIdentity?` | `any` | - | - | node\_modules/bun-types/globals.d.ts:901 |
 | `tls.rejectUnauthorized?` | `boolean` | - | - | node\_modules/bun-types/globals.d.ts:900 |
@@ -45,13 +45,13 @@
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `certificateAuthorityPath?` | `string` \| `string`[] | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.ca` option but only the path. | [src/networkUtils.mts:59](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L59) |
-| `certificatePath` | `string` \| `string`[] | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.cert` option but only the path. | [src/networkUtils.mts:63](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L63) |
-| `diffieHellmanParametersPath?` | `string` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.dhParamsFile` option. | [src/networkUtils.mts:67](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L67) |
-| `lowMemoryMode?` | `boolean` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.lowMemoryMode` option. | [src/networkUtils.mts:71](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L71) |
-| `passphrase?` | `string` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.passphrase` option. | [src/networkUtils.mts:75](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L75) |
-| `privateKeyPath` | `string` \| `string`[] | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.key` option but only the path. | [src/networkUtils.mts:79](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L79) |
-| `serverName?` | `string` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.serverName` option. | [src/networkUtils.mts:83](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L83) |
+| `certificateAuthorityPath?` | `string` \| `string`[] | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.ca` option but only the path. | [src/networkUtils.mts:59](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L59) |
+| `certificatePath` | `string` \| `string`[] | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.cert` option but only the path. | [src/networkUtils.mts:63](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L63) |
+| `diffieHellmanParametersPath?` | `string` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.dhParamsFile` option. | [src/networkUtils.mts:67](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L67) |
+| `lowMemoryMode?` | `boolean` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.lowMemoryMode` option. | [src/networkUtils.mts:71](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L71) |
+| `passphrase?` | `string` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.passphrase` option. | [src/networkUtils.mts:75](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L75) |
+| `privateKeyPath` | `string` \| `string`[] | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.key` option but only the path. | [src/networkUtils.mts:79](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L79) |
+| `serverName?` | `string` | Maps to [`Bun.serve()`](https://bun.sh/docs/api/http#tls)'s `tls.serverName` option. | [src/networkUtils.mts:83](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L83) |
 
 ***
 
@@ -67,7 +67,7 @@
 | ------ | ------ | ------ | ------ | ------ |
 | `error?` | (`this`: `Server`, `request`: `ErrorLike`) => `undefined` \| `Response` \| `Promise`\<`Response`\> \| `Promise`\<`undefined`\> | - | `Pick.error` | node\_modules/bun-types/bun.d.ts:2357 |
 | `hostname?` | `string` | What hostname should the server listen on? **Default** `"0.0.0.0" // listen on all interfaces` **Examples** `"127.0.0.1" // Only listen locally` `"remix.run" // Only listen on remix.run`` note: hostname should not include a {@link port} | `Pick.hostname` | node\_modules/bun-types/bun.d.ts:2412 |
-| `httpsOptions?` | [`HttpsOptions`](networkUtils.md#httpsoptions) | Options for customizing HTTPS functionality. | - | [src/networkUtils.mts:90](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L90) |
+| `httpsOptions?` | [`HttpsOptions`](networkUtils.md#httpsoptions) | Options for customizing HTTPS functionality. | - | [src/networkUtils.mts:90](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L90) |
 | `port?` | `string` \| `number` | What port should the server listen on? **Default** `process.env.PORT || "3000"` | `Pick.port` | node\_modules/bun-types/bun.d.ts:2383 |
 
 ## Functions
@@ -97,7 +97,7 @@ Data returned by `fetch`.
 
 #### Defined in
 
-[src/networkUtils.mts:104](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L104)
+[src/networkUtils.mts:104](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L104)
 
 ***
 
@@ -126,4 +126,4 @@ functionality.
 
 #### Defined in
 
-[src/networkUtils.mts:191](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/networkUtils.mts#L191)
+[src/networkUtils.mts:191](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/networkUtils.mts#L191)

--- a/documentation/performanceUtils.md
+++ b/documentation/performanceUtils.md
@@ -4,7 +4,7 @@
 
 ### measureCpuUsage()
 
-> **measureCpuUsage**\<`T`\>(`runner`, `startTime`): `Promise`\<readonly [`Awaited`\<`T`\>, `number`]\>
+> **measureCpuUsage**\<`T`\>(`runner`, `usesOneThread`, `startTime`): `Promise`\<readonly [`Awaited`\<`T`\>, `number`]\>
 
 Measure the CPU usage in percent of the provided runner function.
 
@@ -16,10 +16,11 @@ Measure the CPU usage in percent of the provided runner function.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| ------ | ------ | ------ |
-| `runner` | () => `T` \| `Promise`\<`T`\> | Function whose CPU usage to measure. |
-| `startTime` | `number` | Optional time in milliseconds when the elapsed time starts counting. |
+| Parameter | Type | Default value | Description |
+| ------ | ------ | ------ | ------ |
+| `runner` | () => `T` \| `Promise`\<`T`\> | `undefined` | Function whose CPU usage to measure. |
+| `usesOneThread` | `boolean` | `false` | Optional boolean to decide if 1 or all threads should be used to compute the percent value. |
+| `startTime` | `number` | `...` | Optional time in milliseconds when the elapsed time starts counting. |
 
 #### Returns
 
@@ -29,13 +30,13 @@ A tuple containing the return value of the passed-in function and the CPU usage 
 
 #### Defined in
 
-[src/performanceUtils.mts:18](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/performanceUtils.mts#L18)
+[src/performanceUtils.mts:19](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/performanceUtils.mts#L19)
 
 ***
 
 ### measurePerformanceMetrics()
 
-> **measurePerformanceMetrics**\<`T`\>(`metricName`, `request`, `runner`, `metricDescription`?): `Promise`\<readonly [`Awaited`\<`T`\>, `number`, `number`]\>
+> **measurePerformanceMetrics**\<`T`\>(`metricName`, `request`, `runner`, `metricDescription`?, `usesOneThread`?): `Promise`\<readonly [`Awaited`\<`T`\>, `number`, `number`]\>
 
 Measure performance metrics of the provided runner function. Specifically, `Server-Timing`
 duration and CPU usage percent is computed.
@@ -48,12 +49,13 @@ duration and CPU usage percent is computed.
 
 #### Parameters
 
-| Parameter | Type | Description |
-| ------ | ------ | ------ |
-| `metricName` | `string` | Name of the `Server-Timing` metric being measured. |
-| `request` | `Request` | `Request` object to which the `Server-Timing` header will be appended. |
-| `runner` | () => `T` \| `Promise`\<`T`\> | Function whose execution duration and CPU usage percentage will be computed. |
-| `metricDescription`? | `string` | Optional description of the `Server-Timing` metric being measured. |
+| Parameter | Type | Default value | Description |
+| ------ | ------ | ------ | ------ |
+| `metricName` | `string` | `undefined` | Name of the `Server-Timing` metric being measured. |
+| `request` | `Request` | `undefined` | `Request` object to which the `Server-Timing` header will be appended. |
+| `runner` | () => `T` \| `Promise`\<`T`\> | `undefined` | Function whose execution duration and CPU usage percentage will be computed. |
+| `metricDescription`? | `string` | `undefined` | Optional description of the `Server-Timing` metric being measured. |
+| `usesOneThread`? | `boolean` | `false` | Optional boolean to decide if 1 or all threads should be used to compute the percent value. |
 
 #### Returns
 
@@ -63,4 +65,4 @@ A tuple containing the return value of the passed-in function, the execution dur
 
 #### Defined in
 
-[src/performanceUtils.mts:41](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/performanceUtils.mts#L41)
+[src/performanceUtils.mts:47](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/performanceUtils.mts#L47)

--- a/documentation/routerUtils.md
+++ b/documentation/routerUtils.md
@@ -45,7 +45,7 @@ Constructor that creates an empty array for route definitions.
 
 ###### Defined in
 
-[src/routerUtils.mts:60](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L60)
+[src/routerUtils.mts:60](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L60)
 
 #### Methods
 
@@ -76,7 +76,7 @@ router.all('/**', () => new Response('', { headers: { allow: 'GET' }, status: 40
 
 ###### Defined in
 
-[src/routerUtils.mts:159](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L159)
+[src/routerUtils.mts:159](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L159)
 
 ##### delete()
 
@@ -105,7 +105,7 @@ router.delete('/item', { deleteItemRoute: () => import('./routes/deleteItemRoute
 
 ###### Defined in
 
-[src/routerUtils.mts:173](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L173)
+[src/routerUtils.mts:173](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L173)
 
 ##### get()
 
@@ -134,7 +134,7 @@ router.get('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Defined in
 
-[src/routerUtils.mts:187](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L187)
+[src/routerUtils.mts:187](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L187)
 
 ##### handleRequest()
 
@@ -156,7 +156,7 @@ A `Response` object to build the response sent to the requester.
 
 ###### Defined in
 
-[src/routerUtils.mts:94](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L94)
+[src/routerUtils.mts:94](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L94)
 
 ##### head()
 
@@ -185,7 +185,7 @@ router.head('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
 
 ###### Defined in
 
-[src/routerUtils.mts:201](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L201)
+[src/routerUtils.mts:201](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L201)
 
 ##### options()
 
@@ -214,7 +214,7 @@ router.options('/item', { deleteItemRoute: () => import('./routes/deleteItemRout
 
 ###### Defined in
 
-[src/routerUtils.mts:215](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L215)
+[src/routerUtils.mts:215](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L215)
 
 ##### patch()
 
@@ -243,7 +243,7 @@ router.patch('/item', { patchItemRoute: () => import('./routes/patchItemRoute.mt
 
 ###### Defined in
 
-[src/routerUtils.mts:229](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L229)
+[src/routerUtils.mts:229](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L229)
 
 ##### post()
 
@@ -272,7 +272,7 @@ router.post('/item', { postItemRoute: () => import('./routes/postItemRoute.mts')
 
 ###### Defined in
 
-[src/routerUtils.mts:243](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L243)
+[src/routerUtils.mts:243](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L243)
 
 ##### put()
 
@@ -301,7 +301,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 ###### Defined in
 
-[src/routerUtils.mts:257](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L257)
+[src/routerUtils.mts:257](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L257)
 
 ## Type Aliases
 
@@ -311,7 +311,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Defined in
 
-[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L12)
+[src/routerUtils.mts:12](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L12)
 
 ***
 
@@ -321,7 +321,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Defined in
 
-[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L16)
+[src/routerUtils.mts:16](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L16)
 
 ***
 
@@ -331,7 +331,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Defined in
 
-[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L15)
+[src/routerUtils.mts:15](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L15)
 
 ***
 
@@ -351,7 +351,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Defined in
 
-[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L13)
+[src/routerUtils.mts:13](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L13)
 
 ***
 
@@ -361,7 +361,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Defined in
 
-[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L14)
+[src/routerUtils.mts:14](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L14)
 
 ***
 
@@ -371,7 +371,7 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Defined in
 
-[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L17)
+[src/routerUtils.mts:17](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L17)
 
 ## Variables
 
@@ -381,4 +381,4 @@ router.put('/item', { putItemRoute: () => import('./routes/putItemRoute.mts') })
 
 #### Defined in
 
-[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/routerUtils.mts#L20)
+[src/routerUtils.mts:20](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/routerUtils.mts#L20)

--- a/documentation/timeUtils.md
+++ b/documentation/timeUtils.md
@@ -8,9 +8,9 @@
 
 | Property | Type | Description | Defined in |
 | ------ | ------ | ------ | ------ |
-| `localeOverride?` | `string` | Override of the locale used to format and localize the time value. | [src/timeUtils.mts:19](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/timeUtils.mts#L19) |
-| `unitsMinimum?` | `"ns"` \| `"μs"` \| `"ms"` \| `"s"` | Smallest time unit that can be displayed. | [src/timeUtils.mts:23](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/timeUtils.mts#L23) |
-| `unitsOverride?` | `"ns"` \| `"μs"` \| `"ms"` \| `"s"` | Override of time units to display; supersedes `unitsMinimum`. | [src/timeUtils.mts:27](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/timeUtils.mts#L27) |
+| `localeOverride?` | `string` | Override of the locale used to format and localize the time value. | [src/timeUtils.mts:19](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/timeUtils.mts#L19) |
+| `unitsMinimum?` | `"ns"` \| `"μs"` \| `"ms"` \| `"s"` | Smallest time unit that can be displayed. | [src/timeUtils.mts:23](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/timeUtils.mts#L23) |
+| `unitsOverride?` | `"ns"` \| `"μs"` \| `"ms"` \| `"s"` | Override of time units to display; supersedes `unitsMinimum`. | [src/timeUtils.mts:27](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/timeUtils.mts#L27) |
 
 ## Functions
 
@@ -46,7 +46,7 @@ request.headers.append(...buildServerTimingHeader('metric', startTime, 'It measu
 
 #### Defined in
 
-[src/timeUtils.mts:51](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/timeUtils.mts#L51)
+[src/timeUtils.mts:51](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/timeUtils.mts#L51)
 
 ***
 
@@ -72,7 +72,7 @@ Localized string showing elapsed time with units.
 
 #### Defined in
 
-[src/timeUtils.mts:66](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/timeUtils.mts#L66)
+[src/timeUtils.mts:66](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/timeUtils.mts#L66)
 
 ***
 
@@ -102,7 +102,7 @@ A tuple containing the return value of the passed-in function and the elapsed ex
 
 #### Defined in
 
-[src/timeUtils.mts:106](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/timeUtils.mts#L106)
+[src/timeUtils.mts:106](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/timeUtils.mts#L106)
 
 ***
 
@@ -147,7 +147,7 @@ const [cmsContent, cmsLoadDuration] = await measureServerTiming('cmsLoad', reque
 
 #### Defined in
 
-[src/timeUtils.mts:131](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/timeUtils.mts#L131)
+[src/timeUtils.mts:131](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/timeUtils.mts#L131)
 
 ***
 
@@ -180,7 +180,7 @@ console.log(metrics); // Logs: [{ name: "metricName", description: undefined, du
 
 #### Defined in
 
-[src/timeUtils.mts:156](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/timeUtils.mts#L156)
+[src/timeUtils.mts:156](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/timeUtils.mts#L156)
 
 ***
 
@@ -204,4 +204,4 @@ Asynchronous sleep function using promises.
 
 #### Defined in
 
-[src/timeUtils.mts:172](https://github.com/mangs/bun-utils/blob/bd5aa48bbccdeadada54ddefbe4f12bcb52f3fe3/src/timeUtils.mts#L172)
+[src/timeUtils.mts:172](https://github.com/mangs/bun-utils/blob/ddf8fc5d259598ada653cd5483b2e845cd3de44b/src/timeUtils.mts#L172)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.23.1",
+  "version": "2.24.0",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {


### PR DESCRIPTION
**Pull Request Checklist**

- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)
- [x] (OPTIONAL) Build updated documentation using `package.json` script `build:documentation`

**Changes Included**

- Version bump to `2.24.0`
- Add additional parameter `usesOneThread` to `measureCpuUsage()` and `measurePerformanceMetrics()` to decide if 1 or all threads are used for percent computation