### PR TITLE
Remove the sidebar from Wiki documentation so full table widths can be seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.27.1
+
+- Remove the sidebar from Wiki documentation so full table widths can be seen
+
 ## 2.27.0
 
 - Auto-generate documentation when merging every pull request into the `main` branch, then commit it to the `Wiki` section of the repository

--- a/config/typedoc/typedoc.json
+++ b/config/typedoc/typedoc.json
@@ -16,8 +16,7 @@
   "propertiesFormat": "table",
   "readme": "none",
   "sidebar": {
-    "autoConfiguration": true,
-    "heading": "Utils"
+    "autoConfiguration": false
   },
   "sort": ["alphabetical"],
   "typeDeclarationFormat": "table"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `2.27.1`
- Remove the sidebar from Wiki documentation so full table widths can be seen