### PR TITLE
Add type `ServerTimingMetricParsed` missing from documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.27.2
+
+- Add type `ServerTimingMetricParsed` missing from documentation
+
 ## 2.27.1
 
 - Remove the sidebar from Wiki documentation so full table widths can be seen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.27.1",
+  "version": "2.27.2",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/src/timeUtils.mts
+++ b/src/timeUtils.mts
@@ -184,4 +184,4 @@ export {
   parseServerTimingMetrics,
   sleep,
 };
-export type { FormatOptions };
+export type { FormatOptions, ServerTimingMetricParsed };


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `2.27.2`
- Add type `ServerTimingMetricParsed` missing from documentation