### PR TITLE
Add back sidebar generation because a sidebar column is always shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.27.3
+
+- Add back sidebar generation because a sidebar column is always shown
+
 ## 2.27.2
 
 - Add type `ServerTimingMetricParsed` missing from documentation

--- a/config/typedoc/typedoc.json
+++ b/config/typedoc/typedoc.json
@@ -16,7 +16,8 @@
   "propertiesFormat": "table",
   "readme": "none",
   "sidebar": {
-    "autoConfiguration": false
+    "autoConfiguration": true,
+    "heading": "Utils"
   },
   "sort": ["alphabetical"],
   "typeDeclarationFormat": "table"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.27.2",
+  "version": "2.27.3",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `2.27.3`
- Add back sidebar generation because a sidebar column is always shown