### PR TITLE
Add request body logging to `startDevelopmentServer()` with option toggle `shouldLogRequestBody` to control it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.29.0
+
+- Add request body logging to `startDevelopmentServer()` with option toggle `shouldLogRequestBody` to control it
+
 ## 2.28.0
 
 - Add a performance label to the failure cases of `scripts/bun/checkEnvironmentVersions.mts`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `2.29.0`
- Add request body logging to `startDevelopmentServer()` with option toggle `shouldLogRequestBody` to control it