### PR TITLE
Change request body logging option `shouldLogRequestBody` to `onLogRequestBody()` to give more configuration flexibility in `startDevelopmentServer()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.30.0
+
+- Change request body logging option `shouldLogRequestBody` to `onLogRequestBody()` to give more configuration flexibility in `startDevelopmentServer()`
+
 ## 2.29.0
 
 - Add request body logging to `startDevelopmentServer()` with option toggle `shouldLogRequestBody` to control it

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/src/networkUtils.mts
+++ b/src/networkUtils.mts
@@ -91,7 +91,7 @@ interface ServerConfiguration extends Pick<ServeOptions, 'error' | 'hostname' | 
   /**
    * Choose whether incoming request body contents should be logged
    */
-  shouldLogRequestBody?: boolean;
+  onLogRequestBody?: (request: Request, response: Response) => boolean;
 }
 
 // Local Functions
@@ -196,7 +196,13 @@ async function startDevelopmentServer(
   entrypointFunction: Serve['fetch'],
   serverConfiguration: ServerConfiguration = {},
 ) {
-  const { error, hostname, httpsOptions, port, shouldLogRequestBody = true } = serverConfiguration;
+  const {
+    error,
+    hostname,
+    httpsOptions,
+    onLogRequestBody = () => true,
+    port,
+  } = serverConfiguration;
   const serverOptions: Serve = {
     development: true,
     async fetch(request: Request, server: Server): Promise<Response> {
@@ -229,8 +235,8 @@ async function startDevelopmentServer(
         throw responseError;
       }
       if (
-        shouldLogRequestBody &&
         ['DELETE', 'PATCH', 'POST', 'PUT'].includes(request.method) &&
+        onLogRequestBody(request, response) &&
         !request.bodyUsed
       ) {
         // const isJsonBody = requestClone.headers.get('content-type') === 'application/json';


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `2.30.0`
- Change request body logging option `shouldLogRequestBody` to `onLogRequestBody()` to give more configuration flexibility in `startDevelopmentServer()`