### PR TITLE
Add a `getOrHead()` matcher to the router for matching `GET` or `HEAD` requests with a single configuration definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.32.0
+
+- Add a `getOrHead()` matcher to the router for matching `GET` or `HEAD` requests with a single configuration definition
+
 ## 2.31.2
 
 - Improve request logging in the development server by using `Request` cloning

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.31.2",
+  "version": "2.32.0",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/src/routerUtils.mts
+++ b/src/routerUtils.mts
@@ -189,6 +189,20 @@ class Router {
   }
 
   /**
+   * Register a route handler that matches the `GET` or `HEAD` HTTP request methods.
+   * @param path         A path-like string that will be used to match against the incoming request's path.
+   * @param routeHandler The function that will execute if this route handler is matched. Eagerly-loaded route handlers pass functions in directly; lazy-loaded ones pass in an object whose key corresponds to a module's named export or `'default'` for default export.
+   * @returns            A reference to the instantiated instance (`this`) so route handler definitions can be chained.
+   * @example
+   * ```ts
+   * router.getOrHead('/*', { pageRoute: () => import('./routes/pageRoute.mts') })
+   * ```
+   */
+  getOrHead(path: string, routeHandler: RouteHandler) {
+    return this.#handleMethod(path, routeHandler, 'GET').#handleMethod(path, routeHandler, 'HEAD');
+  }
+
+  /**
    * Register a route handler that matches the `HEAD` HTTP request method.
    * @param path         A path-like string that will be used to match against the incoming request's path.
    * @param routeHandler The function that will execute if this route handler is matched. Eagerly-loaded route handlers pass functions in directly; lazy-loaded ones pass in an object whose key corresponds to a module's named export or `'default'` for default export.


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `2.32.0`
- Add a `getOrHead()` matcher to the router for matching `GET` or `HEAD` requests with a single configuration definition