### PR TITLE
Add error `cause` information when errors are thrown by `fetchWithRetry()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.33.4
+
+- Add error `cause` information when errors are thrown by `fetchWithRetry()`
+
 ## 2.33.3
 
 - Move `sharp` from `optionalDependencies` to `devDependencies` so it isn't forcibly installed for all consumers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.33.3",
+  "version": "2.33.4",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/src/networkUtils.mts
+++ b/src/networkUtils.mts
@@ -127,7 +127,7 @@ async function fetchWithRetry(url: Request | string | URL, options: FetchRetryOp
     }
     return response;
   } catch (error) {
-    if (error instanceof Error && hasRetriesRemaining) {
+    if (hasRetriesRemaining) {
       if (process.env.DEBUG) {
         console.debug('ERROR RETRY SETTINGS', { retries, retryDelay });
         console.debug('ERROR', error);
@@ -139,7 +139,12 @@ async function fetchWithRetry(url: Request | string | URL, options: FetchRetryOp
         retryDelay: onChangeRetryDelay(retryDelay),
       });
     }
-    throw error;
+
+    if (error instanceof Error) {
+      error.cause = { retries, retryDelay, timeout };
+      throw error;
+    }
+    throw new Error('Unexpected error', { cause: { error } });
   }
 }
 


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `2.33.4`
- Add error `cause` information when errors are thrown by `fetchWithRetry()`