### PR TITLE
Remove JSDoc `@file` annotations because they are unsupported by TypeDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.33.6
+
+- Remove JSDoc `@file` annotations because they are unsupported by TypeDoc
+
 ## 2.33.5
 
 - Upgrade dependency versions to latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangs/bun-utils",
-  "version": "2.33.5",
+  "version": "2.33.6",
   "author": "Eric L. Goldstein",
   "description": "Useful utils for your Bun projects",
   "engines": {

--- a/src/buildUtils.mts
+++ b/src/buildUtils.mts
@@ -1,7 +1,3 @@
-/**
- * @file Build- and bundler-related utilities.
- */
-
 // External Imports
 import { build, file, nanoseconds, stringWidth } from 'bun';
 import nodePath from 'node:path';

--- a/src/consoleUtils.mts
+++ b/src/consoleUtils.mts
@@ -1,7 +1,3 @@
-/**
- * @file Console-related utilities.
- */
-
 // External Imports
 import { styleText } from 'node:util';
 

--- a/src/filesystemUtils.mts
+++ b/src/filesystemUtils.mts
@@ -1,7 +1,3 @@
-/**
- * @file Filesystem-related utilities.
- */
-
 // External Imports
 import { file } from 'bun';
 import { access, constants, readdir, unlink } from 'node:fs/promises';

--- a/src/networkUtils.mts
+++ b/src/networkUtils.mts
@@ -1,7 +1,3 @@
-/**
- * @file Network-related utlity functions.
- */
-
 // External Imports
 import { file, inspect, serve, stringWidth } from 'bun';
 import { format } from 'node:util';

--- a/src/performanceUtils.mts
+++ b/src/performanceUtils.mts
@@ -1,7 +1,3 @@
-/**
- * @file Performance-related utilities.
- */
-
 // External Imports
 import { availableParallelism } from 'node:os';
 

--- a/src/routerUtils.mts
+++ b/src/routerUtils.mts
@@ -1,7 +1,3 @@
-/**
- * @file Router-related utlity functions.
- */
-
 // External Imports
 import { Glob } from 'bun';
 

--- a/src/timeUtils.mts
+++ b/src/timeUtils.mts
@@ -1,7 +1,3 @@
-/**
- * @file Time-related utilities.
- */
-
 // External Imports
 import { nanoseconds } from 'bun';
 


### PR DESCRIPTION
**Pull Request Checklist**

- [ ] (OPTIONAL) Readme updates were made reflecting this Pull Request's changes

**Changes Included**

- Version bump to `2.33.6`
- Remove JSDoc `@file` annotations because they are unsupported by TypeDoc